### PR TITLE
Fix crash when config is null and initiate defaultSaveConfig to default

### DIFF
--- a/src/main/java/me/cortex/voxy/client/config/VoxyConfig.java
+++ b/src/main/java/me/cortex/voxy/client/config/VoxyConfig.java
@@ -32,7 +32,7 @@ public class VoxyConfig {
     public int savingThreads = 4;
     public int renderThreads = 5;
     public boolean useMeshShaderIfPossible = true;
-    public String defaultSaveConfig;
+    public String defaultSaveConfig = ContextSelectionSystem.DEFAULT_STORAGE_CONFIG;
 
 
     public static VoxyConfig loadOrCreate() {

--- a/src/main/java/me/cortex/voxy/client/saver/ContextSelectionSystem.java
+++ b/src/main/java/me/cortex/voxy/client/saver/ContextSelectionSystem.java
@@ -68,9 +68,10 @@ public class ContextSelectionSystem {
                 try {
                     this.config = Serialization.GSON.fromJson(Files.readString(json), WorldConfig.class);
                     if (this.config == null) {
-                        throw new IllegalStateException("Config deserialization null, reverting to default");
+                        System.err.println("Config deserialization null, reverting to default");
+                    } else {
+                        return;
                     }
-                    return;
                 } catch (Exception e) {
                     System.err.println("Failed to load the storage configuration file, resetting it to default");
                     e.printStackTrace();


### PR DESCRIPTION
Uses default config instead of crashing when the saves config.json is "null".
Also fixes the cause of the null config by initiating defaultSaveConfig to the DEFAULT_STORAGE_CONFIG.