### PR TITLE
Less Z fighting with DepthFunc GL_LESS+PolyOffset

### DIFF
--- a/src/main/java/me/cortex/voxy/client/core/rendering/post/PostProcessing.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/post/PostProcessing.java
@@ -188,6 +188,12 @@ public class PostProcessing {
         glBindTexture(GL_TEXTURE_2D, this.didSSAO?this.colourSSAO.id:this.colour.id);
         glEnable(GL_DEPTH_TEST);
         glDepthMask(true);
+
+        // This helps avoid some overlap and z fighting in transparency.
+        glEnable( GL_POLYGON_OFFSET_FILL );
+        glPolygonOffset( 1.0f, 4.0f );
+        glDepthFunc(GL_LESS);
+
         this.blitTexture.blit();
         glDisable(GL_DEPTH_TEST);
         glDepthMask(true);

--- a/src/main/java/me/cortex/voxy/client/core/rendering/post/PostProcessing.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/post/PostProcessing.java
@@ -198,6 +198,7 @@ public class PostProcessing {
         glDisable(GL_DEPTH_TEST);
         glDepthMask(true);
         glDisable( GL_POLYGON_OFFSET_FILL );
+        glDepthFunc(GL_LEQUAL);
 
         this.glStateCapture.restore();
     }

--- a/src/main/java/me/cortex/voxy/client/core/rendering/post/PostProcessing.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/post/PostProcessing.java
@@ -197,6 +197,7 @@ public class PostProcessing {
         this.blitTexture.blit();
         glDisable(GL_DEPTH_TEST);
         glDepthMask(true);
+        glDisable( GL_POLYGON_OFFSET_FILL );
 
         this.glStateCapture.restore();
     }


### PR DESCRIPTION
Using a different depth comparison (GL_LESS) and a small polygon offset can almost completely remove any transparency z fighting between the minecraft terrain and the voxy terrain. 