### PR TITLE
Disable SSAO when smooth lighting is disabled.

### DIFF
--- a/src/main/java/me/cortex/voxy/client/core/rendering/post/PostProcessing.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/post/PostProcessing.java
@@ -5,6 +5,7 @@ import me.cortex.voxy.client.core.gl.GlTexture;
 import me.cortex.voxy.client.core.gl.shader.Shader;
 import me.cortex.voxy.client.core.gl.shader.ShaderType;
 import me.cortex.voxy.client.core.rendering.util.GlStateCapture;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.math.MatrixStack;
 import org.joml.Matrix4f;
 import org.lwjgl.opengl.GL11C;
@@ -135,6 +136,8 @@ public class PostProcessing {
     //Computes ssao on the current framebuffer data and updates it
     // this means that translucency wont be effected etc
     public void computeSSAO(Matrix4f projection, MatrixStack stack) {
+        if (!MinecraftClient.isAmbientOcclusionEnabled()) return;
+
         this.didSSAO = true;
 
         this.ssaoComp.bind();


### PR DESCRIPTION
Makes voxy terrain and vanilla terrain look consistent with each other when smooth lighting isn't enabled
![2024-09-11_09 40 35](https://github.com/user-attachments/assets/48c6a451-b373-43a0-a915-4700eb15507e)
![2024-09-11_09 40 55](https://github.com/user-attachments/assets/7c6b6648-abb6-4876-b36f-5e28f4305595)
