### PR TITLE
Add a config option to disable voxy when shaders are enabled.

### DIFF
--- a/src/main/java/me/cortex/voxy/client/config/VoxyConfig.java
+++ b/src/main/java/me/cortex/voxy/client/config/VoxyConfig.java
@@ -4,6 +4,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import me.cortex.voxy.client.core.Capabilities;
+import me.cortex.voxy.client.core.util.IrisUtil;
 import me.cortex.voxy.client.saver.ContextSelectionSystem;
 import net.fabricmc.loader.api.FabricLoader;
 import org.lwjgl.opengl.GL;
@@ -32,8 +33,13 @@ public class VoxyConfig {
     public int savingThreads = 4;
     public int renderThreads = 5;
     public boolean useMeshShaderIfPossible = true;
+    public boolean disableWhenShadersActive = false;
     public String defaultSaveConfig;
 
+    public boolean VoxyShouldBeEnabled() {
+        if (IrisUtil.irisShadersEnabled() && disableWhenShadersActive) return false;
+        return enabled;
+    }
 
     public static VoxyConfig loadOrCreate() {
         var path = getConfigPath();

--- a/src/main/java/me/cortex/voxy/client/config/VoxyConfigScreenFactory.java
+++ b/src/main/java/me/cortex/voxy/client/config/VoxyConfigScreenFactory.java
@@ -106,6 +106,12 @@ public class VoxyConfigScreenFactory implements ModMenuApi {
                 .setDefaultValue(DEFAULT.useMeshShaderIfPossible)
                 .build());
 
+        category.addEntry(entryBuilder.startBooleanToggle(Text.translatable("voxy.config.general.shaderAutoDisable"), config.disableWhenShadersActive)
+                .setTooltip(Text.translatable("voxy.config.general.shaderAutoDisable.tooltip"))
+                .setSaveConsumer(val -> config.disableWhenShadersActive = val)
+                .setDefaultValue(DEFAULT.disableWhenShadersActive)
+                .build());
+
         //category.addEntry(entryBuilder.startIntSlider(Text.translatable("voxy.config.general.compression"), config.savingCompressionLevel, 1, 21)
         //        .setTooltip(Text.translatable("voxy.config.general.compression.tooltip"))
         //        .setSaveConsumer(val -> config.savingCompressionLevel = val)

--- a/src/main/java/me/cortex/voxy/client/core/util/IrisUtil.java
+++ b/src/main/java/me/cortex/voxy/client/core/util/IrisUtil.java
@@ -1,7 +1,14 @@
 package me.cortex.voxy.client.core.util;
 
+import me.cortex.voxy.client.core.IGetVoxelCore;
 import net.fabricmc.loader.api.FabricLoader;
+import net.irisshaders.iris.Iris;
+import net.irisshaders.iris.api.v0.IrisApi;
+import net.irisshaders.iris.apiimpl.IrisApiV0Impl;
+import net.irisshaders.iris.config.IrisConfig;
 import net.irisshaders.iris.shadows.ShadowRenderer;
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 public class IrisUtil {
@@ -15,4 +22,6 @@ public class IrisUtil {
     public static boolean irisShadowActive() {
         return IRIS_INSTALLED && irisShadowActive0();
     }
+
+    public static boolean irisShadersEnabled() { return IRIS_INSTALLED && Iris.getIrisConfig().areShadersEnabled(); }
 }

--- a/src/main/java/me/cortex/voxy/client/mixin/iris/MixinIrisShaders.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/iris/MixinIrisShaders.java
@@ -1,0 +1,21 @@
+package me.cortex.voxy.client.mixin.iris;
+
+import me.cortex.voxy.client.core.IGetVoxelCore;
+import net.irisshaders.iris.config.IrisConfig;
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = IrisConfig.class, remap = false)
+public class MixinIrisShaders {
+
+    @Inject(method = "setShadersEnabled", at = @At("RETURN"))
+    private void injectRefresh(boolean enabled, CallbackInfo ci) {
+        var world = (IGetVoxelCore) MinecraftClient.getInstance().worldRenderer;
+        if (world != null && !enabled) {
+            world.reloadVoxelCore();
+        }
+    }
+}

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinWorldRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinWorldRenderer.java
@@ -56,7 +56,7 @@ public abstract class MixinWorldRenderer implements IGetVoxelCore {
         if (this.world != null && this.core != null) {
             this.core.shutdown();
             this.core = null;
-            if (VoxyConfig.CONFIG.enabled) {
+            if (VoxyConfig.CONFIG.VoxyShouldBeEnabled()) {
                 this.populateCore();
             }
         }
@@ -76,7 +76,7 @@ public abstract class MixinWorldRenderer implements IGetVoxelCore {
             this.core.shutdown();
             this.core = null;
         }
-        if (VoxyConfig.CONFIG.enabled) {
+        if (VoxyConfig.CONFIG.VoxyShouldBeEnabled()) {
             this.populateCore();
         }
     }
@@ -87,7 +87,7 @@ public abstract class MixinWorldRenderer implements IGetVoxelCore {
             this.core.shutdown();
             this.core = null;
         }
-        if (this.world != null && VoxyConfig.CONFIG.enabled) {
+        if (this.world != null && VoxyConfig.CONFIG.VoxyShouldBeEnabled()) {
             this.populateCore();
         }
     }

--- a/src/main/resources/assets/voxy/lang/en_us.json
+++ b/src/main/resources/assets/voxy/lang/en_us.json
@@ -19,6 +19,8 @@
   "voxy.config.general.renderDistance.tooltip": "The render distance in chunks (set to -1 to disable chunk unloading)",
   "voxy.config.general.nvmesh": "Use nvidia mesh shaders",
   "voxy.config.general.nvmesh.tooltip": "Use nvidia mesh shaders if possible to render LoDs",
+  "voxy.config.general.shaderAutoDisable": "Automatically disable Voxy with shaders",
+  "voxy.config.general.shaderAutoDisable.tooltip": "Automatically disable Voxy when shaders are applied.",
 
   "voxy.config.threads.ingest": "Ingest",
   "voxy.config.threads.ingest.tooltip": "How many threads voxy will use for ingesting new chunks",

--- a/src/main/resources/voxy.mixins.json
+++ b/src/main/resources/voxy.mixins.json
@@ -11,7 +11,8 @@
     "nvidium.MixinRenderPipeline",
     "sodium.MixinDefaultChunkRenderer",
     "sodium.MixinRenderSectionManager",
-    "sodium.MixinSodiumWorldRender"
+    "sodium.MixinSodiumWorldRender",
+    "iris.MixinIrisShaders"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Added an option (off by default) to the Voxy config that allows users to enable the option to automatically disable voxy when shaders are turned on.