### PR TITLE
NearZ scale slider.

### DIFF
--- a/src/main/java/me/cortex/voxy/client/config/VoxyConfig.java
+++ b/src/main/java/me/cortex/voxy/client/config/VoxyConfig.java
@@ -31,6 +31,7 @@ public class VoxyConfig {
     public int ingestThreads = 2;
     public int savingThreads = 4;
     public int renderThreads = 5;
+    public int nearZScale = 1;
     public boolean useMeshShaderIfPossible = true;
     public String defaultSaveConfig;
 

--- a/src/main/java/me/cortex/voxy/client/config/VoxyConfigScreenFactory.java
+++ b/src/main/java/me/cortex/voxy/client/config/VoxyConfigScreenFactory.java
@@ -106,6 +106,12 @@ public class VoxyConfigScreenFactory implements ModMenuApi {
                 .setDefaultValue(DEFAULT.useMeshShaderIfPossible)
                 .build());
 
+        category.addEntry(entryBuilder.startIntField(Text.translatable("voxy.config.general.nearz"), config.nearZScale)
+                .setTooltip(Text.translatable("voxy.config.general.nearz.tooltip"))
+                .setSaveConsumer(val -> config.nearZScale = val)
+                .setDefaultValue(DEFAULT.nearZScale)
+                .build());
+
         //category.addEntry(entryBuilder.startIntSlider(Text.translatable("voxy.config.general.compression"), config.savingCompressionLevel, 1, 21)
         //        .setTooltip(Text.translatable("voxy.config.general.compression.tooltip"))
         //        .setSaveConsumer(val -> config.savingCompressionLevel = val)

--- a/src/main/java/me/cortex/voxy/client/core/VoxelCore.java
+++ b/src/main/java/me/cortex/voxy/client/core/VoxelCore.java
@@ -164,7 +164,7 @@ public class VoxelCore {
     private static Matrix4f computeProjectionMat() {
         return new Matrix4f(RenderSystem.getProjectionMatrix()).mulLocal(
                 makeProjectionMatrix(0.05f, MinecraftClient.getInstance().gameRenderer.getFarPlaneDistance()).invert()
-        ).mulLocal(makeProjectionMatrix(16, 16*3000));
+        ).mulLocal(makeProjectionMatrix(16*VoxyConfig.CONFIG.nearZScale, 16*3000));
     }
 
     public void renderOpaque(MatrixStack matrices, double cameraX, double cameraY, double cameraZ) {

--- a/src/main/resources/assets/voxy/lang/en_us.json
+++ b/src/main/resources/assets/voxy/lang/en_us.json
@@ -19,6 +19,8 @@
   "voxy.config.general.renderDistance.tooltip": "The render distance in chunks (set to -1 to disable chunk unloading)",
   "voxy.config.general.nvmesh": "Use nvidia mesh shaders",
   "voxy.config.general.nvmesh.tooltip": "Use nvidia mesh shaders if possible to render LoDs",
+  "voxy.config.general.nearz": "Near Z scale",
+  "voxy.config.general.nearz.tooltip": "Scale the Near Z clipping plane",
 
   "voxy.config.threads.ingest": "Ingest",
   "voxy.config.threads.ingest.tooltip": "How many threads voxy will use for ingesting new chunks",


### PR DESCRIPTION
A popular request from people who I know that also use this mod is the ability to change the near clipping plane, by default it's way too close, leading to some strange issues with tree leaves and ghost blocks.