### PR TITLE
Mutliplayer Server Integration (Proof of concept)

### DIFF
--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinClientPacketListener.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinClientPacketListener.java
@@ -3,15 +3,26 @@ package me.cortex.voxy.client.mixin.minecraft;
 import me.cortex.voxy.client.VoxyClientInstance;
 import me.cortex.voxy.client.config.VoxyConfig;
 import me.cortex.voxy.commonImpl.VoxyCommon;
+import me.cortex.voxy.common.world.service.VoxelIngestService;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.network.protocol.game.ClientboundLoginPacket;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.concurrent.CompletableFuture;
+
 @Mixin(ClientPacketListener.class)
-public class MixinClientPacketListener {
+public abstract class MixinClientPacketListener {
+    @Shadow
+    public abstract ClientLevel getLevel();
+
     @Inject(method = "handleLogin", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/game/ClientboundLoginPacket;commonPlayerSpawnInfo()Lnet/minecraft/network/protocol/game/CommonPlayerSpawnInfo;"))
     private void voxy$init(ClientboundLoginPacket packet, CallbackInfo ci) {
         if (VoxyCommon.isAvailable() && !VoxyClientInstance.isInGame) {
@@ -21,6 +32,31 @@ public class MixinClientPacketListener {
                     VoxyCommon.shutdownInstance();
                 }
                 VoxyCommon.createInstance();
+            }
+        }
+    }
+
+    @Inject(method = "handleLevelChunkWithLight", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;packetProcessor()Lnet/minecraft/network/PacketProcessor;"))
+    private void voxy$handleServerChunk(ClientboundLevelChunkWithLightPacket clientboundLevelChunkWithLightPacket, CallbackInfo ci) {
+        if (VoxyCommon.isAvailable() && VoxyClientInstance.isInGame) {
+            if(VoxyConfig.CONFIG.enabled) {
+                var level = getLevel();
+                if(VoxyCommon.getInstance() != null && level != null) {
+                    int x = clientboundLevelChunkWithLightPacket.getX();
+                    int z = clientboundLevelChunkWithLightPacket.getZ();
+                    CompletableFuture.supplyAsync(() -> {
+                        var chunkData = clientboundLevelChunkWithLightPacket.getChunkData();
+                        var worldChunk = new LevelChunk(level, new ChunkPos(x, z));
+                        try {
+                            worldChunk.replaceWithPacketData(chunkData.getReadBuffer(), chunkData.getHeightmaps(), chunkData.getBlockEntitiesTagsConsumer(x, z));
+                        } catch (Exception e) {
+                            System.out.println(e.getMessage());
+                        }
+                        return worldChunk;
+                    }).thenAccept(chunk -> {
+                        VoxelIngestService.tryAutoIngestChunk(chunk);
+                    });
+                }
             }
         }
     }

--- a/src/main/java/me/cortex/voxy/common/config/Serialization.java
+++ b/src/main/java/me/cortex/voxy/common/config/Serialization.java
@@ -116,6 +116,9 @@ public class Serialization {
             if (clzName.endsWith("VoxyConfig")) {
                 continue;//Special case to prevent recursive loading pain
             }
+            if (clzName.contains("VoxyConfigMenu") || clzName.contains("SodiumConfigBuilder")) {
+                continue;//And definitely dont want to crash our server
+            }
 
             if (clzName.equals(Serialization.class.getName())) {
                 continue;//Dont want to load ourselves

--- a/src/main/java/me/cortex/voxy/common/world/service/VoxelIngestService.java
+++ b/src/main/java/me/cortex/voxy/common/world/service/VoxelIngestService.java
@@ -11,6 +11,7 @@ import me.cortex.voxy.common.world.WorldUpdater;
 import me.cortex.voxy.commonImpl.VoxyCommon;
 import me.cortex.voxy.commonImpl.WorldIdentifier;
 import net.minecraft.core.SectionPos;
+import net.minecraft.client.Minecraft;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.chunk.DataLayer;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -129,13 +130,19 @@ public class VoxelIngestService {
             }
         }
 
+        var isSingleplayer = Minecraft.getInstance().isSingleplayer();
+        var player = Minecraft.getInstance().player;
+
+        if(!isSingleplayer) {
+            gotLighting = true;
+        }
+
         if (!gotLighting) {
             return false;
         }
 
         var blp = lightingProvider.getLayerListener(LightLayer.BLOCK);
         var slp = lightingProvider.getLayerListener(LightLayer.SKY);
-
 
         i = chunk.getMinSectionY() - 1;
         for (var section : chunk.getSections()) {
@@ -147,6 +154,12 @@ public class VoxelIngestService {
             var bl = blp.getDataLayerData(pos);
             if (bl != null) {
                 bl = bl.copy();
+            }
+
+            //Use skylight of player chunk as a workaround to being unable to handle far chunk updates on server worlds
+            //FIXME: this will gather the same skylight for all chunks, so they will appear with that repeating light pattern
+            if(!isSingleplayer && player != null) {
+                pos = SectionPos.of(player.chunkPosition(), i);
             }
 
             var sl = slp.getDataLayerData(pos);

--- a/src/main/java/me/cortex/voxy/commonImpl/mixin/chunky/MixinFabricWorld.java
+++ b/src/main/java/me/cortex/voxy/commonImpl/mixin/chunky/MixinFabricWorld.java
@@ -3,15 +3,18 @@ package me.cortex.voxy.commonImpl.mixin.chunky;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.cortex.voxy.common.world.service.VoxelIngestService;
+import me.cortex.voxy.commonImpl.VoxyCommon;
 import net.minecraft.server.level.ChunkResult;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
 import org.popcraft.chunky.mixin.ServerChunkCacheMixin;
 import org.popcraft.chunky.platform.FabricWorld;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 @Mixin(FabricWorld.class)
@@ -19,17 +22,30 @@ public class MixinFabricWorld {
     @WrapOperation(method = "getChunkAtAsync", at = @At(value = "INVOKE", target = "Lorg/popcraft/chunky/mixin/ServerChunkCacheMixin;invokeGetChunkFutureMainThread(IILnet/minecraft/world/level/chunk/status/ChunkStatus;Z)Ljava/util/concurrent/CompletableFuture;"))
     private CompletableFuture<ChunkResult<ChunkAccess>> captureGeneratedChunk(ServerChunkCacheMixin instance, int i, int j, ChunkStatus chunkStatus, boolean b, Operation<CompletableFuture<ChunkResult<ChunkAccess>>> original) {
         var future = original.call(instance, i, j, chunkStatus, b);
-        if (false) {//TODO: ADD SERVER CONFIG THING
-            return future;
-        } else {
-            return future.thenApply(res -> {
-                res.ifSuccess(chunk -> {
-                    if (chunk instanceof LevelChunk worldChunk) {
+        //TODO: do a sweep of chunks around players that just joined, else they'll see no chunks even if they were pregenerated before
+        return future.thenApply(res -> {
+            res.ifSuccess(chunk -> {
+                if (chunk instanceof LevelChunk worldChunk) {
+                    if(VoxyCommon.IS_DEDICATED_SERVER) {
+                        var level = worldChunk.getLevel();
+                        var id = level.dimension().identifier();
+                        var server = Objects.requireNonNull(level.getServer());
+                        var packet = new ClientboundLevelChunkWithLightPacket(worldChunk, level.getLightEngine(), null, null);
+                        for(var levels : server.getAllLevels()) {
+                            if (levels.dimension().identifier().equals(id)) {
+                                for(var player : levels.players()) {
+                                    player.connection.send(packet);
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    else {
                         VoxelIngestService.tryAutoIngestChunk(worldChunk);
                     }
-                });
-                return res;
+                }
             });
-        }
+            return res;
+        });
     }
 }


### PR DESCRIPTION
This is just a proof of concept for multiplayer with voxy, sending generated chunks to the clients and ingesting them with voxy. Does not have any throttling or thread safe models at all, so things will go south somewhere.
There's some lighting bugs due to server limitations, such as not being able to register light updates for distant chunks, so some workarounds had to be made.
Shaders like Photon have their own lighting program, and it kinda fixes some of it, but not all.

Needs voxy to be installed in the server too, along with sodium.
Ideally, you'd store generated voxels in the server and send them to the clients based on their location and radius.
The process only works if players are in the server during distant chunk generation!

Screenshots taken with a voxy render distance of 288 and chunky radius of 2048-ish
<img width="1280" height="720" alt="2025-12-21_03 06 48" src="https://github.com/user-attachments/assets/95ff6899-d854-4ab4-b45c-e011223b1386" />
<img width="1280" height="720" alt="2025-12-21_03 07 32" src="https://github.com/user-attachments/assets/56098956-ed82-4b7c-abe3-6cd45217b065" />
<img width="1280" height="720" alt="2025-12-21_03 11 14" src="https://github.com/user-attachments/assets/fb54e47e-62da-45da-a63f-c298cbf703a5" />

