### PR TITLE
Fix AMD Occlusion Culling (Read-Side Hack) - Fixes #179

### DIFF
--- a/src/main/java/me/cortex/voxy/client/core/rendering/util/HiZBuffer.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/util/HiZBuffer.java
@@ -36,18 +36,23 @@ public class HiZBuffer {
     public HiZBuffer() {
         this(GL_DEPTH24_STENCIL8);
     }
+
     public HiZBuffer(int type) {
         glNamedFramebufferDrawBuffer(this.fb.id, GL_NONE);
         this.type = type;
     }
 
     private void alloc(int width, int height) {
-        this.levels = (int)Math.ceil(Math.log(Math.max(width, height))/Math.log(2));
-        //We dont care about e.g. 1x1 size texture since you dont get meshlets that big to cover such a large area
-        //this.levels -= 1;//Arbitrary size, shinks the max level by alot and saves a significant amount of processing time
-        // (could probably increase it to be defined by a max meshlet coverage computation thing)
+        this.levels = (int) Math.ceil(Math.log(Math.max(width, height)) / Math.log(2));
+        // We dont care about e.g. 1x1 size texture since you dont get meshlets that big
+        // to cover such a large area
+        // this.levels -= 1;//Arbitrary size, shinks the max level by alot and saves a
+        // significant amount of processing time
+        // (could probably increase it to be defined by a max meshlet coverage
+        // computation thing)
 
-        //GL_DEPTH_COMPONENT32F //Cant use this as it does not match the depth format of the provided depth buffer
+        // GL_DEPTH_COMPONENT32F //Cant use this as it does not match the depth format
+        // of the provided depth buffer
         this.texture = new GlTexture().store(this.type, this.levels, width, height).name("HiZ");
         glTextureParameteri(this.texture.id, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
         glTextureParameteri(this.texture.id, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -61,7 +66,7 @@ public class HiZBuffer {
         glSamplerParameteri(this.sampler, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glSamplerParameteri(this.sampler, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-        this.width  = width;
+        this.width = width;
         this.height = height;
 
         this.fb.bind(GL_DEPTH_ATTACHMENT, this.texture, 0).verify();
@@ -84,26 +89,34 @@ public class HiZBuffer {
         glDepthMask(true);
         glEnable(GL_DEPTH_TEST);
 
-
         glBindTextureUnit(0, srcDepthTex);
+        // FORCE PARAMETERS: Ensure the depth texture is treated as a plain texture, not
+        // a shadow map
+        // This is crucial for RDNA1 cards which might default to Comparison Mode
+        glTextureParameteri(srcDepthTex, GL_TEXTURE_COMPARE_MODE, GL_NONE);
+        // We use Nearest because we want raw values
+        glTextureParameteri(srcDepthTex, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTextureParameteri(srcDepthTex, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         glBindSampler(0, this.sampler);
         glUniform1i(0, 0);
         int cw = this.width;
         int ch = this.height;
         for (int i = 0; i < this.levels; i++) {
             this.fb.bind(GL_DEPTH_ATTACHMENT, this.texture, i);
-            glViewport(0, 0, cw, ch); cw = Math.max(cw/2, 1); ch = Math.max(ch/2, 1);
+            glViewport(0, 0, cw, ch);
+            cw = Math.max(cw / 2, 1);
+            ch = Math.max(ch / 2, 1);
             glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
             glTextureBarrier();
-            glMemoryBarrier(GL_FRAMEBUFFER_BARRIER_BIT|GL_TEXTURE_FETCH_BARRIER_BIT);
+            glMemoryBarrier(GL_FRAMEBUFFER_BARRIER_BIT | GL_TEXTURE_FETCH_BARRIER_BIT);
             glTextureParameteri(this.texture.id, GL_TEXTURE_BASE_LEVEL, i);
             glTextureParameteri(this.texture.id, GL_TEXTURE_MAX_LEVEL, i);
-            if (i==0) {
+            if (i == 0) {
                 glBindTextureUnit(0, this.texture.id);
             }
         }
         glTextureParameteri(this.texture.id, GL_TEXTURE_BASE_LEVEL, 0);
-        glTextureParameteri(this.texture.id, GL_TEXTURE_MAX_LEVEL, 1000);//TODO: CHECK IF ITS -1 or -0
+        glTextureParameteri(this.texture.id, GL_TEXTURE_MAX_LEVEL, 1000);// TODO: CHECK IF ITS -1 or -0
 
         glDepthFunc(GL_LEQUAL);
         glDisable(GL_DEPTH_TEST);
@@ -127,6 +140,6 @@ public class HiZBuffer {
     }
 
     public int getPackedLevels() {
-        return (this.width<<16)|this.height;//+1
+        return (this.width << 16) | this.height;// +1
     }
 }

--- a/src/main/resources/assets/voxy/shaders/hiz/blit.fsh
+++ b/src/main/resources/assets/voxy/shaders/hiz/blit.fsh
@@ -7,12 +7,20 @@ layout(binding = 0) uniform sampler2D depthTex;
 layout(location=0) out vec4 colour;
 #endif
 void main() {
-    vec4 depths = textureGather(depthTex, uv, 0); // Get depth values from all surrounding texels.
+    // textureGather can be buggy on some drivers (RDNA1?).
+    // We manually fetch the 4 texels (2x2 reduction) using texelFetch for absolute control.
+    ivec2 basePos = ivec2(gl_FragCoord.xy) * 2;
+    vec4 depths;
+    depths.x = texelFetch(depthTex, basePos + ivec2(0,0), 0).r;
+    depths.y = texelFetch(depthTex, basePos + ivec2(1,0), 0).r;
+    depths.z = texelFetch(depthTex, basePos + ivec2(0,1), 0).r;
+    depths.w = texelFetch(depthTex, basePos + ivec2(1,1), 0).r;
 
     bvec4 cv = lessThanEqual(vec4(0.999999999f), depths);
     if (any(cv)) {//Patch holes (its very dodgy but should work :tm:, should clamp it to the first 3 levels)
         depths = mix(vec4(0.0f), depths, cv);
     }
+    // Standard max-reduction
     float res = max(max(depths.x, depths.y), max(depths.z, depths.w));
 
     #ifdef OUTPUT_COLOUR

--- a/src/main/resources/assets/voxy/shaders/lod/hierarchical/screenspace.glsl
+++ b/src/main/resources/assets/voxy/shaders/lod/hierarchical/screenspace.glsl
@@ -149,6 +149,14 @@ bool isCulledByHiz() {
     for (int x = mnbb.x; x<=mxbb.x; x++) {
         for (int y = mnbb.y; y<=mxbb.y; y++) {
             float sp = texelFetch(hizDepthSampler, ivec2(x, y), ml).r;
+
+            // AMD Fix V9: Read-Side Filter
+            // If the sampled depth is exactly 0.0 (or very close), it's the Buggy Sky.
+            // We treat it as 1.0 (Far Plane) so it doesn't occlude anything.
+            if (sp <= 0.0001f) {
+                sp = 1.0f;
+            }
+
             //pointSample2 = max(sp, pointSample2);
             //sp = mix(sp, pointSample, 0.9999999f<=sp);
             pointSample = max(sp, pointSample);

--- a/src/main/resources/assets/voxy/shaders/lod/hierarchical/screenspace.glsl
+++ b/src/main/resources/assets/voxy/shaders/lod/hierarchical/screenspace.glsl
@@ -39,7 +39,7 @@ bool checkPointInView(vec4 point) {
 
 vec3 minBB = vec3(0.0f);
 vec3 maxBB = vec3(0.0f);
-bool frustumCulled = false;
+bool insideFrustum = false;
 
 float screenSize = 0.0f;
 
@@ -60,10 +60,10 @@ void setupScreenspace(in UnpackedNode node) {
 
     vec3 basePos = vec3(((node.pos<<node.lodLevel)-camSecPos)<<5)-camSubSecPos;
 
-    frustumCulled = outsideFrustum(frustum, basePos, float(32<<node.lodLevel));
+    insideFrustum = !outsideFrustum(frustum, basePos, float(32<<node.lodLevel));
 
     //Fast exit
-    if (frustumCulled) {
+    if (!insideFrustum) {
         return;
     }
 
@@ -122,15 +122,12 @@ void setupScreenspace(in UnpackedNode node) {
 
 //Checks if the node is implicitly culled (outside frustum)
 bool outsideFrustum() {
-    return frustumCulled;// maxW < 16 is a trick where 16 is the near plane
+    return !insideFrustum;// maxW < 16 is a trick where 16 is the near plane
 
     //|| any(lessThanEqual(minBB, vec3(0.0f, 0.0f, 0.0f))) || any(lessThanEqual(vec3(1.0f, 1.0f, 1.0f), maxBB));
 }
 
 bool isCulledByHiz() {
-    //Things start breaking down if the area is the entire scree, no idea why, just abort if we hit this case
-    if ((maxBB.xy-minBB.xy)==vec2(1.0f)) return false;
-
     ivec2 ssize = ivec2(packedHizSize>>16,packedHizSize&0xFFFF);
     vec2 size = (maxBB.xy-minBB.xy)*ssize;
     float miplevel = log2(max(max(size.x, size.y),1));
@@ -149,14 +146,13 @@ bool isCulledByHiz() {
     for (int x = mnbb.x; x<=mxbb.x; x++) {
         for (int y = mnbb.y; y<=mxbb.y; y++) {
             float sp = texelFetch(hizDepthSampler, ivec2(x, y), ml).r;
-
-            // AMD Fix V9: Read-Side Filter
-            // If the sampled depth is exactly 0.0 (or very close), it's the Buggy Sky.
-            // We treat it as 1.0 (Far Plane) so it doesn't occlude anything.
-            if (sp <= 0.0001f) {
+            // AMD Fix V10: Read-Side Filter (Relaxed)
+            // If the sampled depth is close to 0.0 (Buggy Sky) or just very close to camera,
+            // we force it to 1.0 (Far Plane) to prevent it from acting as an occluder.
+            // Tuning: 0.2 covers potential noise and close-up walls. Over-rendering > Under-rendering.
+            if (sp <= 0.2f) {
                 sp = 1.0f;
             }
-
             //pointSample2 = max(sp, pointSample2);
             //sp = mix(sp, pointSample, 0.9999999f<=sp);
             pointSample = max(sp, pointSample);


### PR DESCRIPTION
This is a fixer I've been testing that fixes a rendering bug on older AMD graphics cards and integrated graphics.

I've created a document and conducted user tests in this [thread](https://discord.com/channels/973046939375505408/1452009870227144834).

From the beginning, I believed that this alone wouldn't be enough to make the mod compatible and stable with all graphics cards, since it's practically a fixer made specifically for my GPU, the RX 580, although some users are reporting it working on other GPUs.

I also don't know how much this affects the mod's performance and stability, but according to user tests, it wasn't affected.

This pull request is mainly intended to get this to you faster and help you get an idea of ​​how to bring support for these graphics cards in future updates.