### PR TITLE
Fix AMD Occlusion Culling (Read-Side Hack) - Fixes #179

### DIFF
--- a/src/main/resources/assets/voxy/shaders/lod/hierarchical/screenspace.glsl
+++ b/src/main/resources/assets/voxy/shaders/lod/hierarchical/screenspace.glsl
@@ -149,6 +149,14 @@ bool isCulledByHiz() {
     for (int x = mnbb.x; x<=mxbb.x; x++) {
         for (int y = mnbb.y; y<=mxbb.y; y++) {
             float sp = texelFetch(hizDepthSampler, ivec2(x, y), ml).r;
+
+            // AMD Fix V9: Read-Side Filter
+            // If the sampled depth is exactly 0.0 (or very close), it's the Buggy Sky.
+            // We treat it as 1.0 (Far Plane) so it doesn't occlude anything.
+            if (sp <= 0.0001f) {
+                sp = 1.0f;
+            }
+
             //pointSample2 = max(sp, pointSample2);
             //sp = mix(sp, pointSample, 0.9999999f<=sp);
             pointSample = max(sp, pointSample);


### PR DESCRIPTION
(Reopened on the correct branch.)

This is a fixer I've been testing that fixes a rendering bug on older AMD graphics cards and integrated graphics.

I've created a document and conducted user tests in this [thread](https://discord.com/channels/973046939375505408/1452009870227144834).

From the beginning, I believed that this alone wouldn't be enough to make the mod compatible and stable with all graphics cards, since it's practically a fixer made specifically for my GPU, the RX 580, although some users are reporting it working on other GPUs.

I also don't know how much this affects the mod's performance and stability, but according to user tests, it wasn't affected.

This pull request is mainly intended to get this to you faster and help you get an idea of ​​how to bring support for these graphics cards in future updates.