### PR TITLE
fix translucent lod stitching artifacts

### DIFF
--- a/src/main/resources/assets/voxy/shaders/lod/quad_util.glsl
+++ b/src/main/resources/assets/voxy/shaders/lod/quad_util.glsl
@@ -18,8 +18,11 @@ ivec3 extractLoDPosition(uvec2 encPos) {
     return ivec3(x,y,z);
 }
 
-vec4 getFaceSize(uint faceData) {
+vec4 getFaceSize(uint faceData, bool isTranslucent) {
     float EPSILON = 0.00005f;
+    if (isTranslucent) {
+        EPSILON = 0.0f;
+    }
 
     vec4 faceOffsetsSizes = extractFaceSizes(faceData);
 
@@ -143,7 +146,7 @@ void setupQuad(out QuadData quad, const in Quad rawQuad, uvec2 sPos, bool genera
         quad.attributeData.yzw = makeRemainingAttributes(model, rawQuad, lodLevel, face);
     }
 
-    vec4 faceSize = getFaceSize(faceData);
+    vec4 faceSize = getFaceSize(faceData, modelIsTranslucent(model));
     #ifdef USE_SINGLE_TRI
     faceSize *= 2;
     #endif


### PR DESCRIPTION
this fixes visible ring/line artifacts at lod boundaries for translucent blocks (eg water shown in a purplers video)

it was caused by a small quad expansion used to prevent gaps between lods was also applied
to translucent geometry, causing overlapping geometry and visible seams where lod levels meet.

fix:
- getFaceSize now accounts for model translucency
- quad expansion is disabled for translucent models

result:
- gets rid of visible rings around the player for water/translucent blocks
- no regressions for opaque lod stitching
