### PR TITLE
Fix a crashing issue when toggling fullscreen mode

### DIFF
--- a/src/main/java/me/cortex/voxy/client/core/NormalRenderPipeline.java
+++ b/src/main/java/me/cortex/voxy/client/core/NormalRenderPipeline.java
@@ -64,8 +64,11 @@ public class NormalRenderPipeline extends AbstractRenderPipeline {
             this.colourTex = new GlTexture().store(GL_RGBA8, 1, viewport.width, viewport.height);
             this.colourSSAOTex = new GlTexture().store(GL_RGBA8, 1, viewport.width, viewport.height);
 
-            this.fb.framebuffer.bind(GL_COLOR_ATTACHMENT0, this.colourTex).verify();
-            this.fbSSAO.bind(this.fb.getDepthAttachmentType(), this.fb.getDepthTex()).bind(GL_COLOR_ATTACHMENT0, this.colourSSAOTex).verify();
+            this.fb.framebuffer.bind(GL_COLOR_ATTACHMENT0, this.colourTex);
+            this.fbSSAO.bind(this.fb.getDepthAttachmentType(), this.fb.getDepthTex()).bind(GL_COLOR_ATTACHMENT0, this.colourSSAOTex);
+
+            this.fb.framebuffer.verify();
+            this.fbSSAO.verify();
 
 
             glTextureParameterf(this.colourTex.id, GL_TEXTURE_MIN_FILTER, GL_NEAREST);

--- a/src/main/java/me/cortex/voxy/client/core/rendering/util/DepthFramebuffer.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/util/DepthFramebuffer.java
@@ -28,7 +28,7 @@ public class DepthFramebuffer {
                 this.depthBuffer.free();
             }
             this.depthBuffer = new GlTexture().store(this.depthType, 1, width, height);
-            this.framebuffer.bind(this.getDepthAttachmentType(), this.depthBuffer).verify();
+            this.framebuffer.bind(this.getDepthAttachmentType(), this.depthBuffer);
             return true;
         }
         return false;


### PR DESCRIPTION
Prior to this change whenever I would toggle fullscreen mode in minecraft while in a world the game would crash with the error `java.lang.IllegalStateException: Framebuffer incomplete with error code: 36057`. This was caused from the renderer trying to verify the depth textures and something else but the verify method was called prior to the resize changes being applied. From this I quite simply moved the method calls to a little later so that all the dimensions are the same and the game no longer crashes when I toggle fullscreen.


Now I will confess since I know next to nothing about rendering or opengl I did use chatgpt to help but it appears to work and I didn't blindly copy and paste ¯\_(ツ)_/¯