### PR TITLE
Fix: Isolate multiplayer storage by Player UUID to prevent RocksDB lock crashes

### DIFF
--- a/src/main/java/me/cortex/voxy/client/VoxyClientInstance.java
+++ b/src/main/java/me/cortex/voxy/client/VoxyClientInstance.java
@@ -110,7 +110,8 @@ public class VoxyClientInstance extends VoxyInstance {
                     if (info.isRealm()) {
                         basePath = basePath.resolve("realms");
                     } else {
-                        basePath = basePath.resolve(info.ip.replace(":", "_"));
+                        String userSuffix = Minecraft.getInstance().getUser().getProfileId().toString();
+                        basePath = basePath.resolve(info.ip.replace(":", "_")).resolve(userSuffix);
                     }
                 }
             }


### PR DESCRIPTION
This PR addresses issue #348 where the client crashes when running multiple instances (different accounts) from the same game directory and joining the same server.

The Problem:
In VoxyClientInstance.getBasePath(), multiplayer storage paths are currently resolved using only the Server IP. This causes multiple instances to attempt an exclusive RocksDB lock on the same folder, resulting in a fatal RocksDBException.

The Fix:
I have updated the path resolution to include the player's UUID:
`basePath = basePath.resolve(info.ip.replace(":", "_")).resolve(Minecraft.getInstance().getUser().getProfileId().toString());`

This ensures that each account has a unique storage subfolder, allowing for safe multi-boxing and parallel development/testing environments without file lock conflicts.