### PR TITLE
[codex] align 26.1 toolchain with java 25

### DIFF
--- a/.github/workflows/check-does-build-pr.yml
+++ b/.github/workflows/check-does-build-pr.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/check-does-build.yml
+++ b/.github/workflows/check-does-build.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Loom Cache
         uses: actions/cache@v4

--- a/.github/workflows/manual-artifact.yml
+++ b/.github/workflows/manual-artifact.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version "1.14-SNAPSHOT"
+    id 'net.fabricmc.fabric-loom' version "1.15-SNAPSHOT"
     id 'maven-publish'
 }
 def INCLUDE_OTHER_ARCHS = "true".equalsIgnoreCase(project.findProperty("includeOtherArchs"))
@@ -98,11 +98,11 @@ loom {
     accessWidenerPath = file("src/main/resources/voxy.accesswidener")
 }
 
-def modRuntimeOnlyMsk = {arg->}
+def runtimeOnlyMsk = {arg->}
 if (!isInGHA) {
-    modRuntimeOnlyMsk = { arg ->
+    runtimeOnlyMsk = { arg ->
         dependencies {
-            modRuntimeOnly(arg)
+            runtimeOnly(arg)
         }
     }
 }
@@ -110,50 +110,50 @@ if (!isInGHA) {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings loom.officialMojangMappings()
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    //mappings loom.officialMojangMappings()
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 
-    modRuntimeOnlyMsk(fabricApi.module("fabric-api-base", project.fabric_version))
-    modRuntimeOnlyMsk(fabricApi.module("fabric-rendering-fluids-v1", project.fabric_version))
-    modRuntimeOnlyMsk(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
-    modRuntimeOnlyMsk(fabricApi.module("fabric-command-api-v2", project.fabric_version))
+    runtimeOnlyMsk(fabricApi.module("fabric-api-base", project.fabric_api_version))
+    runtimeOnlyMsk(fabricApi.module("fabric-rendering-fluids-v1", project.fabric_api_version))
+    runtimeOnlyMsk(fabricApi.module("fabric-resource-loader-v0", project.fabric_api_version))
+    runtimeOnlyMsk(fabricApi.module("fabric-command-api-v2", project.fabric_api_version))
 
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 
     if (true) {
-        modImplementation "maven.modrinth:sodium:mc1.21.11-0.8.7-fabric"
+        implementation "maven.modrinth:sodium:mc26.1-0.8.7-fabric"
     } else {
-        modImplementation "net.caffeinemc:sodium-fabric:0.8.4-SNAPSHOT+mc1.21.11+"
+        implementation "net.caffeinemc:sodium-fabric:0.8.4-SNAPSHOT+mc1.21.11+"
     }
 
-    modImplementation("maven.modrinth:lithium:mc1.21.11-0.21.0-fabric")
+    implementation("maven.modrinth:lithium:mc26.1-0.22.0-fabric")
 
     //modRuntimeOnlyMsk "drouarb:nvidium:0.4.1-beta4:1.21.6@jar"
-    modCompileOnly "drouarb:nvidium:0.4.1-beta4:1.21.6@jar"
+    compileOnly("drouarb:nvidium:0.4.1-beta4:1.21.6@jar")
 
-    modCompileOnly("maven.modrinth:modmenu:17.0.0-alpha.1")
-    modRuntimeOnlyMsk("maven.modrinth:modmenu:17.0.0-alpha.1")
+    compileOnly("maven.modrinth:modmenu:18.0.0-alpha.8")
+    runtimeOnlyMsk("maven.modrinth:modmenu:18.0.0-alpha.8")
 
-    modCompileOnly("maven.modrinth:iris:1.10.7+1.21.11-fabric")
-    modRuntimeOnlyMsk("maven.modrinth:iris:1.10.7+1.21.11-fabric")
+    compileOnly("maven.modrinth:iris:1.10.8+26.1-fabric")
+    runtimeOnlyMsk("maven.modrinth:iris:1.10.8+26.1-fabric")
 
     //modCompileOnly("maven.modrinth:starlight:1.1.3+1.20.4")
 
     //modCompileOnly("maven.modrinth:immersiveportals:v5.1.7-mc1.20.4")
 
-    modCompileOnly("maven.modrinth:chunky:1.4.54-fabric")
+    compileOnly("maven.modrinth:chunky:1.4.54-fabric")
     //modRuntimeOnlyMsk("maven.modrinth:chunky:1.4.40-fabric")
 
-    modRuntimeOnlyMsk("maven.modrinth:spark:1.10.152-fabric")
-    modRuntimeOnlyMsk("maven.modrinth:fabric-permissions-api:0.3.3")
+    //modRuntimeOnlyMsk("maven.modrinth:spark:1.10.152-fabric")
+    //modRuntimeOnlyMsk("maven.modrinth:fabric-permissions-api:0.3.3")
     //modRuntimeOnly("maven.modrinth:nsight-loader:1.2.0")
 
     //modImplementation('io.github.douira:glsl-transformer:2.0.1')
 
-    modCompileOnly("maven.modrinth:vivecraft:1.21.9-1.3.2-fabric")
+    compileOnly("maven.modrinth:vivecraft:1.21.9-1.3.2-fabric")
 
-    modCompileOnly("maven.modrinth:flashback:rNCr1Rbs")
+    compileOnly("maven.modrinth:flashback:rNCr1Rbs")
 }
 
 
@@ -224,7 +224,7 @@ processIncludeJars {
     }
 }
 
-remapJar {
+jar {
     doFirst {
         delete fileTree(getDestinationDirectory().get())
     }
@@ -280,6 +280,7 @@ dependencies {
     //implementation 'redis.clients:jedis:5.1.0'
 }
 
+/*
 if (!isInGHA) {
     repositories {
         maven {
@@ -292,4 +293,4 @@ if (!isInGHA) {
             exclude group: 'net.fabricmc', module: 'fabric-loader'
         }
     }
-}
+}*/

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ dependencies {
 }
 
 
-def targetJavaVersion = 21
+def targetJavaVersion = 25
 tasks.withType(JavaCompile).configureEach {
     it.options.encoding = "UTF-8"
     it.options.release = targetJavaVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,15 +7,15 @@ org.gradle.daemon = false
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.11
+minecraft_version=26.1
 loader_version=0.18.4
-loom_version=1.14-SNAPSHOT
+loom_version=1.15-SNAPSHOT
 
 # Fabric API
-fabric_version=0.140.2+1.21.11
+fabric_api_version=0.144.3+26.1
 
 
 # Mod Properties
-mod_version = 0.2.13-alpha
+mod_version = 0.2.14-alpha
 maven_group = me.cortex
 archives_base_name = voxy

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/me/cortex/voxy/client/ClientImportManager.java
+++ b/src/main/java/me/cortex/voxy/client/ClientImportManager.java
@@ -44,7 +44,7 @@ public class ClientImportManager extends ImportManager {
                 long delta = Math.max(System.currentTimeMillis() - this.startTime, 1);
 
                 String msg = "Voxy world import finished in " + (delta/1000) + " seconds, averaging " + (int)(total/(delta/1000f)) + " chunks per second";
-                Minecraft.getInstance().gui.getChat().addMessage(Component.literal(msg));
+                Minecraft.getInstance().gui.getChat().addClientSystemMessage(Component.literal(msg));
                 Logger.info(msg);
             });
         }

--- a/src/main/java/me/cortex/voxy/client/VoxyCommands.java
+++ b/src/main/java/me/cortex/voxy/client/VoxyCommands.java
@@ -13,7 +13,8 @@ import me.cortex.voxy.commonImpl.VoxyCommon;
 import me.cortex.voxy.commonImpl.WorldIdentifier;
 import me.cortex.voxy.commonImpl.importers.DHImporter;
 import me.cortex.voxy.commonImpl.importers.WorldImporter;
-import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.Minecraft;
 import net.minecraft.commands.SharedSuggestionProvider;
@@ -37,44 +38,44 @@ import java.util.concurrent.CompletableFuture;
 public class VoxyCommands {
 
     public static LiteralArgumentBuilder<FabricClientCommandSource> register() {
-        var imports = ClientCommandManager.literal("import")
-                .then(ClientCommandManager.literal("world")
-                        .then(ClientCommandManager.argument("world_name", StringArgumentType.string())
+        var imports = ClientCommands.literal("import")
+                .then(ClientCommands.literal("world")
+                        .then(ClientCommands.argument("world_name", StringArgumentType.string())
                                 .suggests(VoxyCommands::importWorldSuggester)
                                 .executes(VoxyCommands::importWorld)))
-                .then(ClientCommandManager.literal("bobby")
-                        .then(ClientCommandManager.argument("world_name", StringArgumentType.string())
+                .then(ClientCommands.literal("bobby")
+                        .then(ClientCommands.argument("world_name", StringArgumentType.string())
                                 .suggests(VoxyCommands::importBobbySuggester)
                                 .executes(VoxyCommands::importBobby)))
-                .then(ClientCommandManager.literal("raw")
-                        .then(ClientCommandManager.argument("path", StringArgumentType.string())
+                .then(ClientCommands.literal("raw")
+                        .then(ClientCommands.argument("path", StringArgumentType.string())
                                 .executes(VoxyCommands::importRaw)))
-                .then(ClientCommandManager.literal("zip")
-                        .then(ClientCommandManager.argument("zipPath", StringArgumentType.string())
+                .then(ClientCommands.literal("zip")
+                        .then(ClientCommands.argument("zipPath", StringArgumentType.string())
                                 .executes(VoxyCommands::importZip)
-                                .then(ClientCommandManager.argument("innerPath", StringArgumentType.string())
+                                .then(ClientCommands.argument("innerPath", StringArgumentType.string())
                                         .executes(VoxyCommands::importZip))))
-                .then(ClientCommandManager.literal("current")
+                .then(ClientCommands.literal("current")
                         .executes(VoxyCommands::importCurrentWorldIn))
-                .then(ClientCommandManager.literal("cancel")
+                .then(ClientCommands.literal("cancel")
                         .executes(VoxyCommands::cancelImport));
 
         if (DHImporter.HasRequiredLibraries) {
             imports = imports
-                    .then(ClientCommandManager.literal("distant_horizons")
-                    .then(ClientCommandManager.argument("sqlDbPath", StringArgumentType.string())
+                    .then(ClientCommands.literal("distant_horizons")
+                    .then(ClientCommands.argument("sqlDbPath", StringArgumentType.string())
                             .executes(VoxyCommands::importDistantHorizons)));
         }
 
-        var debug = ClientCommandManager.literal("debug")
-                .then(ClientCommandManager.literal("verifyTLNChildMask")
+        var debug = ClientCommands.literal("debug")
+                .then(ClientCommands.literal("verifyTLNChildMask")
                         .executes(ctx->verifyTLNs(ctx, false))
-                        .then(ClientCommandManager.argument("attemptRepair", BoolArgumentType.bool())
+                        .then(ClientCommands.argument("attemptRepair", BoolArgumentType.bool())
                                 .executes(ctx->verifyTLNs(ctx, BoolArgumentType.getBool(ctx, "attemptRepair"))))
                 );
 
-        return ClientCommandManager.literal("voxy")//.requires((ctx)-> VoxyCommon.getInstance() != null)
-                .then(ClientCommandManager.literal("reload")
+        return ClientCommands.literal("voxy")//.requires((ctx)-> VoxyCommon.getInstance() != null)
+                .then(ClientCommands.literal("reload")
                         .executes(VoxyCommands::reloadInstance))
                 .then(imports)
                 .then(debug);

--- a/src/main/java/me/cortex/voxy/client/compat/FlashbackCompat.java
+++ b/src/main/java/me/cortex/voxy/client/compat/FlashbackCompat.java
@@ -20,6 +20,7 @@ public class FlashbackCompat {
     }
 
     private static Path getReplayStoragePath0() {
+        /*
         ReplayServer replayServer = Flashback.getReplayServer();
         if (replayServer != null) {
             FlashbackMeta meta = replayServer.getMetadata();
@@ -35,7 +36,7 @@ public class FlashbackCompat {
                     }
                 }
             }
-        }
+        }*/
         return null;
     }
 }

--- a/src/main/java/me/cortex/voxy/client/core/NormalRenderPipeline.java
+++ b/src/main/java/me/cortex/voxy/client/core/NormalRenderPipeline.java
@@ -108,14 +108,14 @@ public class NormalRenderPipeline extends AbstractRenderPipeline {
     protected void finish(Viewport<?> viewport, int sourceFrameBuffer, int srcWidth, int srcHeight) {
         this.finalBlit.bind();
 
-        boolean fogCoversAllRendering = viewport.fogParameters.environmentalEnd()<Minecraft.getInstance().gameRenderer.getRenderDistance();
+        boolean fogCoversAllRendering = viewport.fogParameters.environmentalEnd()<VoxyRenderSystem.getRenderDistance();
 
         if (this.useEnvFog) {
             float start = viewport.fogParameters.environmentalStart();
             float end = viewport.fogParameters.environmentalEnd();
             if (Math.abs(end-start)>1) {
                 float invEndFogDelta = 1f / (end - start);
-                float endDistance = Math.max(Minecraft.getInstance().gameRenderer.getRenderDistance(), 20*16);//TODO: make this constant a config option
+                float endDistance = Math.max(VoxyRenderSystem.getRenderDistance(), 20*16);//TODO: make this constant a config option
                 endDistance *= (float)Math.sqrt(3);
                 float startDelta = -start * invEndFogDelta;
                 glUniform4f(4, invEndFogDelta, startDelta, Math.clamp(endDistance*invEndFogDelta+startDelta, 0, 1),0);//

--- a/src/main/java/me/cortex/voxy/client/core/VoxyRenderSystem.java
+++ b/src/main/java/me/cortex/voxy/client/core/VoxyRenderSystem.java
@@ -374,7 +374,7 @@ public class VoxyRenderSystem {
     private static float getGameFoV() {
         var client = Minecraft.getInstance();
         var gameRenderer = client.gameRenderer;
-        return gameRenderer.getFov(gameRenderer.getMainCamera(), client.getDeltaTracker().getGameTimeDeltaPartialTick(true), true);
+        return gameRenderer.getMainCamera().getFov();
     }
 
     private static Matrix4f makeProjectionMatrix(float near, float far) {
@@ -388,17 +388,21 @@ public class VoxyRenderSystem {
         return projection;
     }
 
+    public static float getRenderDistance() {
+        return Minecraft.getInstance().options.getEffectiveRenderDistance()*16;
+    }
+
     //TODO: Make a reverse z buffer
     private static Matrix4f computeProjectionMat(Matrix4fc base) {
         //THis is a wild and insane problem to have
         // at short render distances the vanilla terrain doesnt end up covering the 16f near plane voxy uses
         // meaning that it explodes (due to near plane clipping).. _badly_ with the rastered culling being wrong in rare cases for the immediate
         // sections rendered after the vanilla render distance
-        float nearVoxy = Minecraft.getInstance().gameRenderer.getRenderDistance()<=32.0f?8f:16f;
+        float nearVoxy = getRenderDistance()<=32.0f?8f:16f;
         nearVoxy = VoxyClient.disableSodiumChunkRender()?0.1f:nearVoxy;
 
         return base.mulLocal(
-                Minecraft.getInstance().gameRenderer.getProjectionMatrix(getGameFoV()).invert(),
+                Minecraft.getInstance().gameRenderer.getGameRenderState().levelRenderState.cameraRenderState.projectionMatrix.invert(new Matrix4f()),
                 new Matrix4f()
         ).mulLocal(makeProjectionMatrix(nearVoxy, 16*3000));
     }

--- a/src/main/java/me/cortex/voxy/client/core/model/ModelFactory.java
+++ b/src/main/java/me/cortex/voxy/client/core/model/ModelFactory.java
@@ -14,8 +14,8 @@ import me.cortex.voxy.common.util.MemoryBuffer;
 import me.cortex.voxy.common.util.Pair;
 import me.cortex.voxy.common.world.other.Mapper;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.color.block.BlockColor;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.color.block.BlockTintSource;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -23,7 +23,8 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
-import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.CardinalLighting;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.biome.Biome;
@@ -216,6 +217,16 @@ public class ModelFactory {
 
         boolean hasDarkenedTextures = (flags&2)!=0;
         boolean isShaded = (flags&1)!=0;
+        ChunkSectionLayer layer = ChunkSectionLayer.SOLID;
+        if ((flags&4)!=0) {
+            layer = ChunkSectionLayer.TRANSLUCENT;
+        } else if ((flags&8)!=0) {
+            layer = ChunkSectionLayer.CUTOUT;
+        }
+        if (bake.state.is(BlockTags.LEAVES)) {
+            layer = ChunkSectionLayer.SOLID;
+        }
+
 
         {//Create texture data
             long ptr = this.bakeScratchBuffer;
@@ -240,7 +251,7 @@ public class ModelFactory {
             }
         }
 
-        var bakeResult = this.processTextureBakeResult(bake.blockId, bake.state, textureData, isShaded, hasDarkenedTextures);
+        var bakeResult = this.processTextureBakeResult(bake.blockId, bake.state, textureData, isShaded, hasDarkenedTextures, layer);
         if (bakeResult!=null) {
             this.uploadResults.add(bakeResult);
         }
@@ -334,7 +345,7 @@ public class ModelFactory {
         }
     }
 
-    private ModelBakeResultUpload processTextureBakeResult(int blockId, BlockState blockState, ColourDepthTextureData[] textureData, boolean isShaded, boolean darkenedTinting) {
+    private ModelBakeResultUpload processTextureBakeResult(int blockId, BlockState blockState, ColourDepthTextureData[] textureData, boolean isShaded, boolean darkenedTinting, ChunkSectionLayer layer) {
         if (this.idMappings[blockId] != -1) {
             //This should be impossible to reach as it means that multiple bakes for the same blockId happened and where inflight at the same time!
             throw new IllegalStateException("Block id already added: " + blockId + " for state: " + blockState);
@@ -367,16 +378,16 @@ public class ModelFactory {
             }
         }
 
-        var colourProvider = getColourProvider(blockState.getBlock());
+        var tintSources = getTintSources(blockState);
 
         boolean isBiomeColourDependent = false;
-        if (colourProvider != null) {
-            isBiomeColourDependent = isBiomeDependentColour(colourProvider, blockState);
+        if (tintSources != null) {
+            isBiomeColourDependent = isBiomeDependentColour(tintSources, blockState);
         }
 
         ModelEntry entry;
         {//Deduplicate same entries
-            entry = new ModelEntry(textureData, clientFluidStateId, isBiomeColourDependent||colourProvider==null?-1:captureColourConstant(colourProvider, blockState, DEFAULT_BIOME)|0xFF000000);
+            entry = new ModelEntry(textureData, clientFluidStateId, isBiomeColourDependent||tintSources==null?-1:captureColourConstant(tintSources, blockState, DEFAULT_BIOME)|0xFF000000);
             int possibleDuplicate = this.modelTexture2id.getInt(entry);
             if (possibleDuplicate != -1) {//Duplicate found
                 this.idMappings[blockId] = possibleDuplicate;
@@ -403,19 +414,8 @@ public class ModelFactory {
             this.fluidStateLUT[modelId] = clientFluidStateId;
         }
 
-        ChunkSectionLayer blockRenderLayer = null;
-        if (blockState.getBlock() instanceof LiquidBlock) {
-            blockRenderLayer = ItemBlockRenderTypes.getRenderLayer(blockState.getFluidState());
-        } else {
-            if (blockState.getBlock() instanceof LeavesBlock) {
-                blockRenderLayer = ChunkSectionLayer.SOLID;
-            } else {
-                blockRenderLayer = ItemBlockRenderTypes.getChunkRenderType(blockState);
-            }
-        }
 
-
-        int checkMode = blockRenderLayer==ChunkSectionLayer.SOLID?TextureUtils.WRITE_CHECK_STENCIL:TextureUtils.WRITE_CHECK_ALPHA;
+        int checkMode = layer==ChunkSectionLayer.SOLID?TextureUtils.WRITE_CHECK_STENCIL:TextureUtils.WRITE_CHECK_ALPHA;
 
 
 
@@ -439,7 +439,7 @@ public class ModelFactory {
         //TODO: special case stuff like vines and glow lichen, where it can be represented by a single double sided quad
         // since that would help alot with perf of lots of vines, can be done by having one of the faces just not exist and the other be in no occlusion mode
 
-        var depths = computeModelDepth(textureData, checkMode, blockRenderLayer!=ChunkSectionLayer.SOLID?TextureUtils.DEPTH_MODE_MIN:TextureUtils.DEPTH_MODE_AVG);
+        var depths = computeModelDepth(textureData, checkMode, layer!=ChunkSectionLayer.SOLID?TextureUtils.DEPTH_MODE_MIN:TextureUtils.DEPTH_MODE_AVG);
 
         //TODO: THIS, note this can be tested for in 2 ways, re render the model with quad culling disabled and see if the result
         // is the same, (if yes then needs double sided quads)
@@ -477,7 +477,7 @@ public class ModelFactory {
         //Each face gets 1 byte, with the top 2 bytes being for whatever
         long metadata = 0;
         metadata |= isBiomeColourDependent?1:0;
-        metadata |= blockRenderLayer == ChunkSectionLayer.TRANSLUCENT?2:0;
+        metadata |= layer == ChunkSectionLayer.TRANSLUCENT?2:0;
         metadata |= needsDoubleSidedQuads?4:0;
         metadata |= ((!isFluid) && !blockState.getFluidState().isEmpty())?8:0;//Has a fluid state accosiacted with it and is not itself a fluid
         metadata |= isFluid?16:0;//Is a fluid
@@ -513,7 +513,7 @@ public class ModelFactory {
 
             //TODO: add alot of config options for the following
             boolean occludesFace = true;
-            occludesFace &= blockRenderLayer != ChunkSectionLayer.TRANSLUCENT;//If its translucent, it doesnt occlude
+            occludesFace &= layer != ChunkSectionLayer.TRANSLUCENT;//If its translucent, it doesnt occlude
 
             //TODO: make this an option, basicly if the face is really close, it occludes otherwise it doesnt
             occludesFace &= offset < 0.1;//If the face is rendered far away from the other face, then it doesnt occlude
@@ -533,7 +533,7 @@ public class ModelFactory {
             metadata |= canBeOccluded?4:0;
 
             //Face uses its own lighting if its not flat against the adjacent block & isnt traslucent
-            metadata |= (offset > 0.01 || blockRenderLayer == ChunkSectionLayer.TRANSLUCENT)?0b1000:0;
+            metadata |= (offset > 0.01 || layer == ChunkSectionLayer.TRANSLUCENT)?0b1000:0;
 
 
 
@@ -556,14 +556,14 @@ public class ModelFactory {
             int area = (faceSize[1]-faceSize[0]+1) * (faceSize[3]-faceSize[2]+1);
             boolean needsAlphaDiscard = ((float)writeCount)/area<0.9;//If the amount of area covered by written pixels is less than a threashold, disable discard as its not needed
 
-            needsAlphaDiscard |= blockRenderLayer != ChunkSectionLayer.SOLID;
-            needsAlphaDiscard &= blockRenderLayer != ChunkSectionLayer.TRANSLUCENT;//Translucent doesnt have alpha discard
+            needsAlphaDiscard |= layer != ChunkSectionLayer.SOLID;
+            needsAlphaDiscard &= layer != ChunkSectionLayer.TRANSLUCENT;//Translucent doesnt have alpha discard
             faceModelData |= needsAlphaDiscard?1<<22:0;
 
-            faceModelData |= ((!faceCoversFullBlock)&&blockRenderLayer != ChunkSectionLayer.TRANSLUCENT)?1<<23:0;//Alpha discard override, translucency doesnt have alpha discard
+            faceModelData |= ((!faceCoversFullBlock)&&layer != ChunkSectionLayer.TRANSLUCENT)?1<<23:0;//Alpha discard override, translucency doesnt have alpha discard
 
             //Bits 24,25 are tint metadata
-            if (colourProvider!=null) {//We have a tint
+            if (tintSources!=null) {//We have a tint
                 int tintState = TextureUtils.computeFaceTint(textureData[face], checkMode);
                 if (tintState == 2) {//Partial tint
                     faceModelData |= 1<<24;
@@ -586,9 +586,9 @@ public class ModelFactory {
         //Have 40 bytes free for remaining model data
         // todo: put in like the render layer type ig? along with colour resolver info
         int modelFlags = 0;
-        modelFlags |= colourProvider != null?1:0;
+        modelFlags |= tintSources != null?1:0;
         modelFlags |= isBiomeColourDependent?2:0;//Basicly whether to use the next int as a colour or as a base index/id into a colour buffer for biome dependent colours
-        modelFlags |= blockRenderLayer == ChunkSectionLayer.TRANSLUCENT?4:0;//Is translucent
+        modelFlags |= layer == ChunkSectionLayer.TRANSLUCENT?4:0;//Is translucent
 
 
         //TODO: THIS
@@ -599,7 +599,7 @@ public class ModelFactory {
 
 
         //Temporary override to always be non biome specific
-        if (colourProvider == null) {
+        if (tintSources == null) {
             MemoryUtil.memPutInt(uploadPtr, -1);//Set the default to nothing so that its faster on the gpu
         } else if (!isBiomeColourDependent) {
             MemoryUtil.memPutInt(uploadPtr, entry.tintingColour);
@@ -612,7 +612,7 @@ public class ModelFactory {
             uploadResult.biomeUploadIndex = biomeIndex;
             long clrUploadPtr = (uploadResult.biomeUpload = new MemoryBuffer(4L * this.biomes.size())).address;
             for (var biome : this.biomes) {
-                MemoryUtil.memPutInt(clrUploadPtr, captureColourConstant(colourProvider, blockState, biome)|0xFF000000); clrUploadPtr += 4;
+                MemoryUtil.memPutInt(clrUploadPtr, captureColourConstant(tintSources, blockState, biome)|0xFF000000); clrUploadPtr += 4;
             }
         }
         uploadPtr += 4;
@@ -708,7 +708,7 @@ public class ModelFactory {
         int i = 0;
         long modelUpPtr = result.modelBiomeIndexPairs.address;
         for (var entry : this.modelsRequiringBiomeColours) {
-            var colourProvider = getColourProvider(entry.right().getBlock());
+            var colourProvider = getTintSources(entry.right());
             if (colourProvider == null) {
                 throw new IllegalStateException();
             }
@@ -727,19 +727,24 @@ public class ModelFactory {
         return result;
     }
 
-    private static BlockColor getColourProvider(Block block) {
-        return Minecraft.getInstance().getBlockColors().blockColors.byId(BuiltInRegistries.BLOCK.getId(block));
+    private static List<BlockTintSource> getTintSources(BlockState block) {
+        if (block.getBlock() instanceof LiquidBlock) {//If is pure fluid
+            var tintSource = Minecraft.getInstance().getModelManager().getFluidStateModelSet().get(block.getFluidState()).tintSource();
+            if (tintSource == null) return null;
+            return List.of(tintSource);
+        } else {
+            var tints = Minecraft.getInstance().getBlockColors().getTintSources(block);
+            if (tints.isEmpty()) return null;
+            //TODO: check if all the elements inside the tint are null, if so return null
+            return tints;
+        }
     }
 
     //TODO: add a method to detect biome dependent colours (can do by detecting if getColor is ever called)
     // if it is, need to add it to a list and mark it as biome colour dependent or something then the shader
     // will either use the uint as an index or a direct colour multiplier
-    private static int captureColourConstant(BlockColor colorProvider, BlockState state, Biome biome) {
+    private static int captureColourConstant(List<BlockTintSource> tintSources, BlockState state, Biome biome) {
         var getter = new BlockAndTintGetter() {
-            @Override
-            public float getShade(Direction direction, boolean shaded) {
-                return 0;
-            }
 
             @Override
             public int getBrightness(LightLayer type, BlockPos pos) {
@@ -748,15 +753,16 @@ public class ModelFactory {
 
             @Override
             public LevelLightEngine getLightEngine() {
-                return null;
+                return LevelLightEngine.EMPTY;
+            }
+
+            @Override
+            public CardinalLighting cardinalLighting() {
+                return CardinalLighting.DEFAULT;
             }
 
             @Override
             public int getBlockTint(BlockPos pos, ColorResolver colorResolver) {
-                if (colorResolver == null) {
-                    Logger.error("Block state: " + state + " colourprovider: " + colorProvider + " had a null colorresolver");
-                    return 0;
-                }
                 return colorResolver.getColor(biome, 0, 0);
             }
 
@@ -786,19 +792,19 @@ public class ModelFactory {
                 return 0;
             }
         };
-        //Multiple layer bs to do with flower beds
-        int c = colorProvider.getColor(state, getter, BlockPos.ZERO, 0);
-        if (c!=-1) return c;
-        return colorProvider.getColor(state, getter, BlockPos.ZERO, 1);
+        for (var source : tintSources) {
+            if (source != null) {
+                //Multiple layer bs to do with flower beds
+                int c = source.colorInWorld(state, getter, BlockPos.ZERO);
+                if (c!=-1) return c;
+            }
+        }
+        return -1;
     }
 
-    private static boolean isBiomeDependentColour(BlockColor colorProvider, BlockState state) {
+    private static boolean isBiomeDependentColour(List<BlockTintSource> tintSources, BlockState state) {
         boolean[] biomeDependent = new boolean[1];
         var getter = new BlockAndTintGetter() {
-            @Override
-            public float getShade(Direction direction, boolean shaded) {
-                return 0;
-            }
 
             @Override
             public int getBrightness(LightLayer type, BlockPos pos) {
@@ -807,7 +813,12 @@ public class ModelFactory {
 
             @Override
             public LevelLightEngine getLightEngine() {
-                return null;
+                return LevelLightEngine.EMPTY;
+            }
+
+            @Override
+            public CardinalLighting cardinalLighting() {
+                return CardinalLighting.DEFAULT;
             }
 
             @Override
@@ -842,8 +853,11 @@ public class ModelFactory {
                 return 0;
             }
         };
-        colorProvider.getColor(state, getter, BlockPos.ZERO, 0);
-        colorProvider.getColor(state, getter, BlockPos.ZERO, 1);
+        for (var source : tintSources) {
+            if (source != null) {
+                source.colorInWorld(state, getter, BlockPos.ZERO);
+            }
+        }
         return biomeDependent[0];
     }
 

--- a/src/main/java/me/cortex/voxy/client/core/model/bakery/ReuseVertexConsumer.java
+++ b/src/main/java/me/cortex/voxy/client/core/model/bakery/ReuseVertexConsumer.java
@@ -3,8 +3,9 @@ package me.cortex.voxy.client.core.model.bakery;
 
 import me.cortex.voxy.common.util.MemoryBuffer;
 import net.minecraft.client.model.geom.builders.UVPair;
-import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.texture.MipmapStrategy;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
 import org.lwjgl.system.MemoryUtil;
 
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -18,9 +19,15 @@ public final class ReuseVertexConsumer implements VertexConsumer {
 
     public boolean anyShaded;
     public boolean anyDarkendTex;
+    public boolean anyDiscard;
 
+    private final int globalOrMetadata;
     public ReuseVertexConsumer() {
+        this(0);
+    }
+    public ReuseVertexConsumer(int globalOrMetadata) {
         this.reset();
+        this.globalOrMetadata = globalOrMetadata;
     }
 
     public ReuseVertexConsumer setDefaultMeta(int meta) {
@@ -28,11 +35,15 @@ public final class ReuseVertexConsumer implements VertexConsumer {
         return this;
     }
 
+    public int getDefaultMeta() {
+        return this.defaultMeta;
+    }
+
     @Override
     public ReuseVertexConsumer addVertex(float x, float y, float z) {
         this.ensureCanPut();
         this.ptr += VERTEX_FORMAT_SIZE; this.count++; //Goto next vertex
-        this.meta(this.defaultMeta);
+        this.meta(this.defaultMeta|this.globalOrMetadata);
         MemoryUtil.memPutFloat(this.ptr, x);
         MemoryUtil.memPutFloat(this.ptr + 4, y);
         MemoryUtil.memPutFloat(this.ptr + 8, z);
@@ -40,6 +51,7 @@ public final class ReuseVertexConsumer implements VertexConsumer {
     }
 
     public ReuseVertexConsumer meta(int metadata) {
+        this.anyDiscard |= (metadata&1)!=0;
         MemoryUtil.memPutInt(this.ptr + 12, metadata);
         return this;
     }
@@ -81,9 +93,20 @@ public final class ReuseVertexConsumer implements VertexConsumer {
         return null;
     }
 
+    public ReuseVertexConsumer quad(BakedQuad quad) {
+        return this.quad(quad, false);
+    }
+
+    public ReuseVertexConsumer quad(BakedQuad quad, boolean forceSolid) {
+        int meta = 0;
+        meta |= forceSolid?0:(quad.materialInfo().layer()!=ChunkSectionLayer.SOLID?1:0);//has discard
+        meta |= quad.materialInfo().isTinted()?4:0;//has tinting
+        return this.quad(quad, meta);
+    }
+
     public ReuseVertexConsumer quad(BakedQuad quad, int metadata) {
-        this.anyShaded |= quad.shade();
-        this.anyDarkendTex |= quad.sprite().contents().mipmapStrategy == MipmapStrategy.DARK_CUTOUT;
+        this.anyShaded |= quad.materialInfo().shade();
+        this.anyDarkendTex |= quad.materialInfo().sprite().contents().mipmapStrategy == MipmapStrategy.DARK_CUTOUT;
         this.ensureCanPut();
         for (int i = 0; i < 4; i++) {
             var pos = quad.position(i);
@@ -91,7 +114,7 @@ public final class ReuseVertexConsumer implements VertexConsumer {
             long puv = quad.packedUV(i);
             this.setUv(UVPair.unpackU(puv),UVPair.unpackV(puv));
 
-            this.meta(metadata);
+            this.meta(metadata|this.globalOrMetadata);
         }
         return this;
     }
@@ -112,6 +135,7 @@ public final class ReuseVertexConsumer implements VertexConsumer {
     public ReuseVertexConsumer reset() {
         this.anyShaded = false;
         this.anyDarkendTex = false;
+        this.anyDiscard = false;
         this.defaultMeta = 0;//RESET THE DEFAULT META
         this.count = 0;
         this.ptr = this.buffer.address - VERTEX_FORMAT_SIZE;//the thing is first time this gets incremented by FORMAT_STRIDE

--- a/src/main/java/me/cortex/voxy/client/core/model/bakery/SoftwareModelTextureBakery.java
+++ b/src/main/java/me/cortex/voxy/client/core/model/bakery/SoftwareModelTextureBakery.java
@@ -9,12 +9,16 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import me.cortex.voxy.client.core.model.ModelFactory;
 import me.cortex.voxy.common.util.UnsafeUtil;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.FluidRenderer;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.Identifier;
-import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.CardinalLighting;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
@@ -34,6 +38,8 @@ import org.lwjgl.system.MemoryUtil;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.lwjgl.opengl.GL11.glFinish;
@@ -42,10 +48,13 @@ public class SoftwareModelTextureBakery {
     //Note: the first bit of metadata is if alpha discard is enabled
     private static final Matrix4f[] VIEWS = new Matrix4f[6];
 
-    private final ReuseVertexConsumer vc = new ReuseVertexConsumer();
+    private final ReuseVertexConsumer opaqueVC = new ReuseVertexConsumer();
+    private final ReuseVertexConsumer translucentVC = new ReuseVertexConsumer(1/*has discard*/);
     private final SoftwareRasterizer rasterizer = new SoftwareRasterizer();
 
+    private final FluidRenderer fr;
     public SoftwareModelTextureBakery() {
+        this.fr = new FluidRenderer(Minecraft.getInstance().getModelManager().getFluidStateModelSet());
     }
 
     public void setupTexture() {
@@ -87,56 +96,34 @@ public class SoftwareModelTextureBakery {
         }
     }
 
-    public static int getMetaFromLayer(ChunkSectionLayer layer) {
-        boolean hasDiscard = layer == ChunkSectionLayer.CUTOUT ||
-                layer == ChunkSectionLayer.TRANSLUCENT||
-                layer == ChunkSectionLayer.TRIPWIRE;
-
-        int meta = hasDiscard?1:0;
-        meta |= true?2:0;
-        return meta;
-    }
-
-    private void bakeBlockModel(BlockState state, ChunkSectionLayer layer) {
+    private void bakeBlockModel(BlockState state) {
         if (state.getRenderShape() == RenderShape.INVISIBLE) {
             return;//Dont bake if invisible
         }
         var model = Minecraft.getInstance()
                 .getModelManager()
-                .getBlockModelShaper()
-                .getBlockModel(state);
+                .getBlockStateModelSet()
+                .get(state);
 
-        int meta = getMetaFromLayer(layer);
-
-        for (var part : model.collectParts(new SingleThreadedRandomSource(42L))) {
+        List<BlockStateModelPart> out = new ArrayList<>();
+        model.collectParts(new SingleThreadedRandomSource(42L), out);
+        for (var part : out) {
             for (Direction direction : new Direction[]{Direction.DOWN, Direction.UP, Direction.NORTH, Direction.SOUTH, Direction.WEST, Direction.EAST, null}) {
                 var quads = part.getQuads(direction);
                 for (var quad : quads) {
-                    this.vc.quad(quad, meta|(quad.isTinted()?4:0));
+                    (quad.materialInfo().layer()==ChunkSectionLayer.TRANSLUCENT?this.translucentVC:this.opaqueVC)
+                            .quad(quad, state.is(BlockTags.LEAVES));
                 }
             }
         }
     }
 
 
-    private void bakeFluidState(BlockState state, ChunkSectionLayer layer, int face) {
-        {
-            //TODO: somehow set the tint flag per quad or something?
-            int metadata = getMetaFromLayer(layer);
-            //Just assume all fluids are tinted, if they arnt it should be implicitly culled in the model baking phase
-            // since it wont have the colour provider
-            metadata |= 4;//Has tint
-            this.vc.setDefaultMeta(metadata);//Set the meta while baking
-        }
-        Minecraft.getInstance().getBlockRenderer().renderLiquid(BlockPos.ZERO, new BlockAndTintGetter() {
-            @Override
-            public float getShade(Direction direction, boolean shaded) {
-                return 0;
-            }
-
+    private void bakeFluidState(BlockState state, int face) {
+        this.fr.tesselate(new BlockAndTintGetter() {
             @Override
             public LevelLightEngine getLightEngine() {
-                return null;
+                return LevelLightEngine.EMPTY;
             }
 
             @Override
@@ -145,8 +132,18 @@ public class SoftwareModelTextureBakery {
             }
 
             @Override
+            public CardinalLighting cardinalLighting() {
+                return CardinalLighting.DEFAULT;
+            }
+
+            @Override
             public int getBlockTint(BlockPos pos, ColorResolver colorResolver) {
-                return 0;
+                //This is such a stupid and bad hack, we can inject tinting state here since this is called
+                // before the quad is added
+                //TODO: need to make a quad once tinting thing
+                translucentVC.setDefaultMeta(translucentVC.getDefaultMeta()|4);//Tinting
+                opaqueVC.setDefaultMeta(opaqueVC.getDefaultMeta()|4);//Tinting
+                return -1;
             }
 
             @Nullable
@@ -191,8 +188,17 @@ public class SoftwareModelTextureBakery {
             public int getMinY() {
                 return 0;
             }
-        }, this.vc, state, state.getFluidState());
-        this.vc.setDefaultMeta(0);//Reset default meta
+        }, BlockPos.ZERO, layer->{
+            if (layer == ChunkSectionLayer.TRANSLUCENT) return this.translucentVC;
+            if (layer == ChunkSectionLayer.CUTOUT) {
+                this.opaqueVC.setDefaultMeta(this.opaqueVC.getDefaultMeta()|1);//set discard
+            } else {
+                this.opaqueVC.setDefaultMeta(this.opaqueVC.getDefaultMeta()&~1);//remove discard
+            }
+            return this.opaqueVC;
+        }, state, state.getFluidState());
+        this.translucentVC.setDefaultMeta(0);//Reset default meta
+        this.opaqueVC.setDefaultMeta(0);//Reset default meta
     }
 
     private static boolean shouldReturnAirForFluid(BlockPos pos, int face) {
@@ -202,7 +208,8 @@ public class SoftwareModelTextureBakery {
     }
 
     public void free() {
-        this.vc.free();
+        this.opaqueVC.free();
+        this.translucentVC.free();
     }
 
     private static final long SINGLE_FACE_OUTPUT_SIZE = (ModelFactory.MODEL_TEXTURE_SIZE * ModelFactory.MODEL_TEXTURE_SIZE)*8;
@@ -214,16 +221,8 @@ public class SoftwareModelTextureBakery {
 
 
         boolean isBlock = true;
-        ChunkSectionLayer layer;
         if (state.getBlock() instanceof LiquidBlock) {
-            layer = ItemBlockRenderTypes.getRenderLayer(state.getFluidState());
             isBlock = false;
-        } else {
-            if (state.getBlock() instanceof LeavesBlock) {
-                layer = ChunkSectionLayer.SOLID;
-            } else {
-                layer = ItemBlockRenderTypes.getChunkRenderType(state);
-            }
         }
 
         //TODO: support block model entities
@@ -232,25 +231,26 @@ public class SoftwareModelTextureBakery {
             //bbem = BakedBlockEntityModel.bake(state);
         }
 
-        {
-            this.rasterizer.setBlending(layer == ChunkSectionLayer.TRANSLUCENT);
-
-            //var tex = Minecraft.getInstance().getTextureManager().getTexture(Identifier.fromNamespaceAndPath("minecraft", "textures/atlas/blocks.png")).getTexture();
-            //blockTextureId = ((com.mojang.blaze3d.opengl.GlTexture)tex).glId();
-        }
-
         boolean isAnyShaded = false;
         boolean isAnyDarkend = false;
+        boolean anyTranslucent = false;
+        boolean anyDiscard = false;
         if (isBlock) {
-            this.vc.reset();
-            this.bakeBlockModel(state, layer);
-            isAnyShaded |= this.vc.anyShaded;
-            isAnyDarkend |= this.vc.anyDarkendTex;
-            if (!this.vc.isEmpty()) {//only render if there... is shit to render
+            this.opaqueVC.reset();
+            this.translucentVC.reset();
+            this.bakeBlockModel(state);
+            isAnyShaded |= this.opaqueVC.anyShaded|this.translucentVC.anyShaded;
+            isAnyDarkend |= this.opaqueVC.anyDarkendTex|this.translucentVC.anyDarkendTex;
+            anyTranslucent |= !this.translucentVC.isEmpty();
+            anyDiscard |= this.opaqueVC.anyDiscard;
+            if (!(this.opaqueVC.isEmpty()&&this.translucentVC.isEmpty())) {//only render if there... is shit to render
                 for (int i = 0; i < VIEWS.length; i++) {
                     this.rasterizer.setFaceCull(i==1||i==2||i==4);
-
-                    this.rasterizer.raster(VIEWS[i], this.vc);
+                    this.rasterizer.clear();
+                    this.rasterizer.setBlending(false);
+                    this.rasterizer.raster(VIEWS[i], this.opaqueVC);
+                    this.rasterizer.setBlending(true);
+                    this.rasterizer.raster(VIEWS[i], this.translucentVC);
                     UnsafeUtil.memcpy(this.rasterizer.getRawFramebuffer(), outputBuffer+(SINGLE_FACE_OUTPUT_SIZE*i));
                 }
             }
@@ -258,22 +258,28 @@ public class SoftwareModelTextureBakery {
 
             if (!(state.getBlock() instanceof LiquidBlock)) throw new IllegalStateException();
             for (int i = 0; i < VIEWS.length; i++) {
-                this.vc.reset();
-                this.bakeFluidState(state, layer, i);
-                if (this.vc.isEmpty()) continue;
-                isAnyShaded |= this.vc.anyShaded;
-                isAnyDarkend |= this.vc.anyDarkendTex;
+                this.opaqueVC.reset();
+                this.translucentVC.reset();
+                this.bakeFluidState(state, i);
+                if (this.opaqueVC.isEmpty()&&this.translucentVC.isEmpty()) continue;
+                isAnyShaded |= this.opaqueVC.anyShaded|this.translucentVC.anyShaded;
+                isAnyDarkend |= this.opaqueVC.anyDarkendTex|this.translucentVC.anyDarkendTex;
+                anyTranslucent |= !this.translucentVC.isEmpty();
+                anyDiscard |= this.opaqueVC.anyDiscard;
 
                 this.rasterizer.setFaceCull(i==1||i==2||i==4);
 
                 //The projection matrix
-                this.rasterizer.raster(VIEWS[i], this.vc);
+                this.rasterizer.clear();
+                this.rasterizer.setBlending(false);
+                this.rasterizer.raster(VIEWS[i], this.opaqueVC);
+                this.rasterizer.setBlending(true);
+                this.rasterizer.raster(VIEWS[i], this.translucentVC);
                 UnsafeUtil.memcpy(this.rasterizer.getRawFramebuffer(), outputBuffer+(SINGLE_FACE_OUTPUT_SIZE*i));
             }
         }
 
-
-        return (isAnyShaded?1:0)|(isAnyDarkend?2:0);
+        return (isAnyShaded?1:0)|(isAnyDarkend?2:0)|(anyTranslucent?4:0)|(anyDiscard?8:0);
     }
 
 

--- a/src/main/java/me/cortex/voxy/client/core/model/bakery/SoftwareRasterizer.java
+++ b/src/main/java/me/cortex/voxy/client/core/model/bakery/SoftwareRasterizer.java
@@ -69,12 +69,15 @@ public class SoftwareRasterizer {
         return this.samplerTexture[this.samplerWidth*pv+pu];
     }
 
-    public void raster(Matrix4f mvp, ReuseVertexConsumer vertices) {
+    public void clear() {
         Arrays.fill(this.framebuffer, CLEAR_VALUE);
+    }
 
+    public void raster(Matrix4f mvp, ReuseVertexConsumer vertices) {
+        if (vertices.isEmpty()) return;
         int qc = vertices.quadCount();
         for (int i = 0; i < qc; i++) {
-            this.rasterQuad(mvp, vertices.getAddress()+ReuseVertexConsumer.VERTEX_FORMAT_SIZE*4*i);
+            this.rasterQuad(mvp, vertices.getAddress()+ReuseVertexConsumer.VERTEX_FORMAT_SIZE*4L*i);
         }
         //Arrays.fill(this.framebuffer, -1);
     }
@@ -170,6 +173,7 @@ public class SoftwareRasterizer {
 
 
         final int ALPHA_CUTOFF_THRESHOLD = 0;
+        //TODO: meta&1 OR if we are blending
         if ((meta&1)!=0 && (colour>>>24)<=ALPHA_CUTOFF_THRESHOLD) {//Discard on small alpha
             return;
         }

--- a/src/main/java/me/cortex/voxy/client/core/rendering/section/backend/AbstractSectionRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/section/backend/AbstractSectionRenderer.java
@@ -71,11 +71,12 @@ public abstract class AbstractSectionRenderer <T extends Viewport<T>, J extends 
     public void addDebug(List<String> lines) {}
 
     protected static void addDirectionalFaceTint(Shader.Builder<?> builder, ClientLevel cl) {
-        builder.define("NO_SHADE_FACE_TINT", cl.getShade(Direction.UP, false));
-        builder.define("UP_FACE_TINT", cl.getShade(Direction.UP, true));
-        builder.define("DOWN_FACE_TINT", cl.getShade(Direction.DOWN, true));
-        builder.define("Z_AXIS_FACE_TINT", cl.getShade(Direction.NORTH, true));//assumed here that Direction.SOUTH returns the same value
-        builder.define("X_AXIS_FACE_TINT", cl.getShade(Direction.EAST, true));//assumed here that Direction.WEST returns the same value
+        var cardinalLight = cl.cardinalLighting();
+        builder.define("NO_SHADE_FACE_TINT", cardinalLight.up());
+        builder.define("UP_FACE_TINT", cardinalLight.up());
+        builder.define("DOWN_FACE_TINT", cardinalLight.down());
+        builder.define("Z_AXIS_FACE_TINT", cardinalLight.north());//assumed here that Direction.SOUTH returns the same value
+        builder.define("X_AXIS_FACE_TINT", cardinalLight.east());//assumed here that Direction.WEST returns the same value
         /*
         //TODO: generate the tinting table here and use the replacement feature
         float[] tints = new float[7];

--- a/src/main/java/me/cortex/voxy/client/core/rendering/util/LightMapHelper.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/util/LightMapHelper.java
@@ -12,6 +12,6 @@ public class LightMapHelper {
     }
 
     public static int getLightmapTextureId() {
-        return ((com.mojang.blaze3d.opengl.GlTexture)(Minecraft.getInstance().gameRenderer.lightTexture().getTextureView().texture())).glId();
+        return ((com.mojang.blaze3d.opengl.GlTexture)(Minecraft.getInstance().gameRenderer.levelLightmap().texture())).glId();
     }
 }

--- a/src/main/java/me/cortex/voxy/client/mixin/iris/MixinLevelRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/iris/MixinLevelRenderer.java
@@ -10,7 +10,10 @@ import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
 import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -27,25 +30,15 @@ public class MixinLevelRenderer {
 
     @Inject(method = "renderLevel", at = @At("HEAD"), order = 100)
     private void voxy$injectIrisCompat(
-            GraphicsResourceAllocator allocator,
-            DeltaTracker tickCounter,
-            boolean renderBlockOutline,
-            Camera camera,
-            Matrix4f positionMatrix,
-            Matrix4f projectionMatrix,
-            Matrix4f basicProjectionMatrix,
-            GpuBufferSlice fogBuffer,
-            Vector4f fogColor,
-            boolean renderSky,
-            CallbackInfo ci) {
+            GraphicsResourceAllocator resourceAllocator, DeltaTracker deltaTracker, boolean renderOutline, CameraRenderState cameraState, Matrix4fc modelViewMatrix, GpuBufferSlice terrainFog, Vector4f fogColor, boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender, CallbackInfo ci) {
         if (IrisUtil.irisShaderPackEnabled()) {
             var renderer = ((IGetVoxyRenderSystem) this).getVoxyRenderSystem();
             if (renderer != null) {
                 //Fixthe fucking viewport dims, fuck iris
                 glViewport(0,0,Minecraft.getInstance().getMainRenderTarget().width, Minecraft.getInstance().getMainRenderTarget().height);
 
-                var pos = camera.position();
-                IrisUtil.CAPTURED_VIEWPORT_PARAMETERS = new IrisUtil.CapturedViewportParameters(new ChunkRenderMatrices(projectionMatrix, positionMatrix), ((FogStorage) this.minecraft.gameRenderer).sodium$getFogParameters(), pos.x, pos.y, pos.z);
+                var pos = cameraState.pos;
+                IrisUtil.CAPTURED_VIEWPORT_PARAMETERS = new IrisUtil.CapturedViewportParameters(new ChunkRenderMatrices(cameraState.projectionMatrix, cameraState.viewRotationMatrix), ((FogStorage) this.minecraft.gameRenderer).sodium$getFogParameters(), pos.x, pos.y, pos.z);
             }
         }
     }

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinClientChunkCache.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinClientChunkCache.java
@@ -20,7 +20,8 @@ public class MixinClientChunkCache implements ICheekyClientChunkCache {
     @Unique
     private static final boolean BOBBY_INSTALLED = FabricLoader.getInstance().isModLoaded("bobby");
 
-    @Shadow volatile ClientChunkCache.Storage storage;
+    @Shadow
+    private volatile ClientChunkCache.Storage storage;
 
     @Override
     public @Nullable LevelChunk voxy$cheekyGetChunk(int x, int z) {
@@ -30,7 +31,7 @@ public class MixinClientChunkCache implements ICheekyClientChunkCache {
             return null;
         }
         //Verify that the position of the chunk is the same as the requested position
-        if (chunk.getPos().x == x && chunk.getPos().z == z) {
+        if (chunk.getPos().x() == x && chunk.getPos().z() == z) {
             return chunk;//The chunk is at the requested position
         }
         //Otherwise return null
@@ -40,7 +41,7 @@ public class MixinClientChunkCache implements ICheekyClientChunkCache {
     @Inject(method = "drop", at = @At("HEAD"))
     public void voxy$captureChunkBeforeUnload(ChunkPos pos, CallbackInfo ci) {
         if (VoxyConfig.CONFIG.ingestEnabled && BOBBY_INSTALLED) {
-            var chunk = this.voxy$cheekyGetChunk(pos.x, pos.z);
+            var chunk = this.voxy$cheekyGetChunk(pos.x(), pos.z());
             if (chunk != null) {
                 VoxelIngestService.tryAutoIngestChunk(chunk);
             }

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinDebugScreenEntryList.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinDebugScreenEntryList.java
@@ -19,6 +19,7 @@ public abstract class MixinDebugScreenEntryList {
     @Shadow @Final private List<Identifier> currentlyEnabled;
     @Shadow public abstract boolean isOverlayVisible();
 
+    @Final
     @Shadow
     private Map<Identifier, DebugScreenEntryStatus> allStatuses;
 

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinFogRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinFogRenderer.java
@@ -18,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = FogRenderer.class,remap = true)
+@Mixin(value = FogRenderer.class, priority = 900)//We must execute before sodium
 public class MixinFogRenderer {
     @Inject(method = "setupFog", at = @At("RETURN"))
     private void voxy$modifyFog(Camera camera, int renderDistanceInChunks, DeltaTracker deltaTracker, float darkenWorldAmount, ClientLevel level, CallbackInfoReturnable<FogData> cir) {

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinFogRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinFogRenderer.java
@@ -20,16 +20,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = FogRenderer.class,remap = true)
 public class MixinFogRenderer {
-    @Inject(method = "setupFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;getDevice()Lcom/mojang/blaze3d/systems/GpuDevice;", remap = false))
-    private void voxy$modifyFog(Camera camera, int rdInt, DeltaTracker tracker, float pTick, ClientLevel lvl, CallbackInfoReturnable<Vector4f> cir, @Local(type=FogData.class) FogData data) {
+    @Inject(method = "setupFog", at = @At("RETURN"))
+    private void voxy$modifyFog(Camera camera, int renderDistanceInChunks, DeltaTracker deltaTracker, float darkenWorldAmount, ClientLevel level, CallbackInfoReturnable<FogData> cir) {
         if (!VoxyConfig.CONFIG.isRenderingEnabled()) return;
 
         var vrs = IGetVoxyRenderSystem.getNullable();
         if (vrs == null) return;
-
-        /*
-        if (!VoxyConfig.CONFIG.useRenderFog) {
-        }*/
+        var data = cir.getReturnValue();
         boolean fogIsDamnClose = data.environmentalEnd<10;
         if (!VoxyConfig.CONFIG.useEnvironmentalFog && !fogIsDamnClose) {
             data.environmentalStart = 99999999;

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinRenderSystem.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinRenderSystem.java
@@ -3,6 +3,7 @@ package me.cortex.voxy.client.mixin.minecraft;
 
 import com.mojang.blaze3d.shaders.ShaderSource;
 import com.mojang.blaze3d.shaders.ShaderType;
+import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderSystem;
 import me.cortex.voxy.client.VoxyClient;
 import net.minecraft.resources.Identifier;
@@ -18,7 +19,7 @@ import java.util.function.BiFunction;
 public class MixinRenderSystem {
     //We need to inject before iris to initalize our systems
     @Inject(method = "initRenderer", order = 900, remap = false, at = @At("RETURN"))
-    private static void voxy$injectInit(long windowHandle, int debugVerbosity, boolean sync, ShaderSource source, boolean renderDebugLabels, CallbackInfo ci) {
+    private static void voxy$injectInit(GpuDevice device, CallbackInfo ci) {
         VoxyClient.initVoxyClient();
     }
 }

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinWindow.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinWindow.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.platform.DisplayData;
 import com.mojang.blaze3d.platform.ScreenManager;
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.platform.WindowEventHandler;
+import com.mojang.blaze3d.systems.GpuBackend;
 import me.cortex.voxy.client.GPUSelectorWindows2;
 import me.cortex.voxy.common.util.ThreadUtils;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Window.class)
 public class MixinWindow {
     @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/platform/Window;setBootErrorCallback()V"))
-    private void injectInitWindow(WindowEventHandler eventHandler, ScreenManager monitorTracker, DisplayData settings, String fullscreenVideoMode, String title, CallbackInfo ci) {
+    private void injectInitWindow(WindowEventHandler eventHandler, DisplayData displayData, String fullscreenVideoModeString, String title, GpuBackend backend, CallbackInfo ci) {
         //System.load("C:\\Program Files\\RenderDoc\\renderdoc.dll");
         var prop = System.getProperty("voxy.forceGpuSelectionIndex", "NO");
         if (!prop.equals("NO")) {

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinRenderSectionManager.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinRenderSectionManager.java
@@ -116,7 +116,7 @@ public class MixinRenderSectionManager {
             var tracker = ((AccessorChunkTracker)ChunkTrackerHolder.get(this.level)).getChunkStatus();
             //in theory the cache value could be wrong but is so soso unlikely and at worst means we either duplicate ingest a chunk
             // which... could be bad ;-; or we dont ingest atall which is ok!
-            long key = ChunkPos.asLong(x, z);
+            long key = ChunkPos.pack(x, z);
             if (key != this.cachedChunkPos) {
                 this.cachedChunkPos = key;
                 this.cachedChunkStatus = tracker.getOrDefault(key, 0);

--- a/src/main/java/me/cortex/voxy/common/world/other/Mapper.java
+++ b/src/main/java/me/cortex/voxy/common/world/other/Mapper.java
@@ -359,7 +359,7 @@ public class Mapper {
             if (state.getBlock() instanceof LeavesBlock) {
                 this.opacity = 15;
             } else {
-                this.opacity = state.getLightBlock();
+                this.opacity = state.getLightDampening();
             }
         }
 

--- a/src/main/java/me/cortex/voxy/common/world/service/VoxelIngestService.java
+++ b/src/main/java/me/cortex/voxy/common/world/service/VoxelIngestService.java
@@ -105,7 +105,7 @@ public class VoxelIngestService {
         boolean allEmpty = true;
         for (var section : chunk.getSections()) {
             i++;
-            if (section == null || !shouldIngestSection(section, chunk.getPos().x, i, chunk.getPos().z)) continue;
+            if (section == null || !shouldIngestSection(section, chunk.getPos().x(), i, chunk.getPos().z())) continue;
             allEmpty&=section.hasOnlyAir();
             //if (section.isEmpty()) continue;
             var pos = SectionPos.of(chunk.getPos(), i);
@@ -119,9 +119,9 @@ public class VoxelIngestService {
             i = chunk.getMinSectionY() - 1;
             for (var section : chunk.getSections()) {
                 i++;
-                if (section == null || !shouldIngestSection(section, chunk.getPos().x, i, chunk.getPos().z)) continue;
+                if (section == null || !shouldIngestSection(section, chunk.getPos().x(), i, chunk.getPos().z())) continue;
                 engine.markActive();
-                this.ingestQueue.add(new IngestSection(chunk.getPos().x, i, chunk.getPos().z, engine, section, null, null));
+                this.ingestQueue.add(new IngestSection(chunk.getPos().x(), i, chunk.getPos().z(), engine, section, null, null));
                 try {
                     this.service.execute();
                 } catch (Exception e) {
@@ -142,7 +142,7 @@ public class VoxelIngestService {
         i = chunk.getMinSectionY() - 1;
         for (var section : chunk.getSections()) {
             i++;
-            if (section == null || !shouldIngestSection(section, chunk.getPos().x, i, chunk.getPos().z)) continue;
+            if (section == null || !shouldIngestSection(section, chunk.getPos().x(), i, chunk.getPos().z())) continue;
             //if (section.isEmpty()) continue;
             var pos = SectionPos.of(chunk.getPos(), i);
 
@@ -161,7 +161,7 @@ public class VoxelIngestService {
             //    continue;
             //}
             engine.markActive();
-            this.ingestQueue.add(new IngestSection(chunk.getPos().x, i, chunk.getPos().z, engine, section, bl, sl));//TODO: fixme, this is technically not safe todo on the chunk load ingest, we need to copy the section data so it cant be modified while being read
+            this.ingestQueue.add(new IngestSection(chunk.getPos().x(), i, chunk.getPos().z(), engine, section, bl, sl));//TODO: fixme, this is technically not safe todo on the chunk load ingest, we need to copy the section data so it cant be modified while being read
             try {
                 this.service.execute();
             } catch (Exception e) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -38,10 +38,10 @@
     "common.voxy.mixins.json"
   ],
   "depends": {
-    "minecraft": ["1.21.11"],
+    "minecraft": ["26.1.0"],
     "fabricloader": ">=0.14.22",
     "fabric-api": ">=0.91.1",
-    "sodium": ["=0.8.4","=0.8.6","=0.8.7"]
+    "sodium": ["=0.8.7"]
   },
   "breaks": {
     "voxyworldgenv2": "=2.2.2"

--- a/src/main/resources/voxy.accesswidener
+++ b/src/main/resources/voxy.accesswidener
@@ -1,11 +1,10 @@
-accessWidener v1 named
+accessWidener v1 official
 
 accessible class net/minecraft/client/multiplayer/ClientChunkCache$Storage
 accessible class com/mojang/blaze3d/opengl/GlDebug$LogEntry
 
 accessible field net/minecraft/client/multiplayer/ClientLevel levelRenderer Lnet/minecraft/client/renderer/LevelRenderer;
 accessible field com/mojang/blaze3d/opengl/GlBuffer handle I
-accessible field net/minecraft/client/color/block/BlockColors blockColors Lnet/minecraft/core/IdMapper;
 accessible field net/minecraft/client/renderer/texture/TextureAtlas maxMipLevel I
 accessible field net/minecraft/client/gui/components/BossHealthOverlay events Ljava/util/Map;
 accessible field net/minecraft/client/multiplayer/MultiPlayerGameMode connection Lnet/minecraft/client/multiplayer/ClientPacketListener;
@@ -15,8 +14,6 @@ accessible field net/minecraft/world/level/chunk/PalettedContainer$Data palette 
 accessible field net/minecraft/world/level/chunk/PalettedContainer$Data storage Lnet/minecraft/util/BitStorage;
 
 accessible field net/minecraft/client/renderer/texture/SpriteContents mipmapStrategy Lnet/minecraft/client/renderer/texture/MipmapStrategy;
-
-accessible method net/minecraft/client/renderer/GameRenderer getFov (Lnet/minecraft/client/Camera;FZ)F
 
 accessible method net/minecraft/client/multiplayer/ClientChunkCache$Storage getChunk (I)Lnet/minecraft/world/level/chunk/LevelChunk;
 accessible method net/minecraft/client/multiplayer/ClientChunkCache$Storage getIndex (II)I


### PR DESCRIPTION
This PR makes the existing Minecraft 26.1 port buildable and testable by aligning the project toolchain with the runtime requirements of 26.1.

Before this change, the branch already contained the source-level 26.1 port work, but the project metadata still targeted Java 21 and an older Gradle wrapper. In practice that meant contributors could not reliably compile or validate the branch against Minecraft 26.1, because the resolved Minecraft jars require Java 25 class support. The result was a class-version mismatch during compilation even though the code itself was largely ready.

This change updates the project Java target from 21 to 25, bumps the Gradle wrapper from 9.2.1 to 9.4.0, and updates the GitHub Actions workflows to use Java 25 as well. That keeps local development and CI aligned with what the 26.1 branch now requires.

Validation:
- `gradlew compileJava`
- `gradlew build`
- launched a 26.1 client successfully and verified Voxy initialized, created its world engine, and ran in a live Realm test session

The runtime logs still contain optional compatibility warnings for mods that were not installed in the test instance, but the core Voxy + Fabric API + Sodium 26.1 path compiled, built, launched, and shut down cleanly.
