### PR TITLE
add try/finally to prevent StampedLock leaks

### DIFF
--- a/src/main/java/me/cortex/voxy/common/world/ActiveSectionTracker.java
+++ b/src/main/java/me/cortex/voxy/common/world/ActiveSectionTracker.java
@@ -223,7 +223,7 @@ public class ActiveSectionTracker {
         WorldSection sec = null;
         final var lock = this.locks[index];
         long stamp = lock.writeLock();
-        {
+        try {
             VarHandle.loadLoadFence();
             if (section.isDirty) {
                 if (section.tryAcquire()) {
@@ -246,6 +246,10 @@ public class ActiveSectionTracker {
                     throw new IllegalStateException("Removed section not the same as the referenced section in the cache: cached: " + obj + " got: " + section + " A: " + WorldSection.ATOMIC_STATE_HANDLE.get(obj) + " B: " +WorldSection.ATOMIC_STATE_HANDLE.get(section));
                 }
                 sec = section;
+            }
+        } finally {
+            if (sec == null) {
+                lock.unlockWrite(stamp);
             }
         }
 

--- a/src/main/java/me/cortex/voxy/commonImpl/VoxyInstance.java
+++ b/src/main/java/me/cortex/voxy/commonImpl/VoxyInstance.java
@@ -142,22 +142,23 @@ public abstract class VoxyInstance {
             return world;
         }
         long stamp = this.activeWorldLock.writeLock();
+        try {
+            if (!this.isRunning) {
+                Logger.error("Tried getting world object on voxy instance but its not running");
+                return null;
+            }
 
-        if (!this.isRunning) {
-            Logger.error("Tried getting world object on voxy instance but its not running");
-            return null;
+            world = this.activeWorlds.get(identifier);
+            if (world == null) {
+                //Create world here
+                world = this.createWorld(identifier);
+            }
+            world.markActive();
+
+            if (incrementRef) world.acquireRef();
+        } finally {
+            this.activeWorldLock.unlockWrite(stamp);
         }
-
-        world = this.activeWorlds.get(identifier);
-        if (world == null) {
-            //Create world here
-            world = this.createWorld(identifier);
-        }
-        world.markActive();
-
-        if (incrementRef) world.acquireRef();
-
-        this.activeWorldLock.unlockWrite(stamp);
         identifier.cachedEngineObject = new WeakReference<>(world);
         return world;
     }


### PR DESCRIPTION
getOrCreate() leaked activeWorldLock on early return (!isRunning) or exception from createWorld(). tryUnload() leaked the shard write lock when trySetFreed() threw IllegalStateException.