### PR TITLE
Fix projection matrix calculation if backend is Zero-to-One

### DIFF
--- a/src/main/java/me/cortex/voxy/client/core/VoxyRenderSystem.java
+++ b/src/main/java/me/cortex/voxy/client/core/VoxyRenderSystem.java
@@ -2,6 +2,7 @@ package me.cortex.voxy.client.core;
 
 import com.mojang.blaze3d.opengl.GlConst;
 import com.mojang.blaze3d.opengl.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
 import me.cortex.voxy.client.TimingStatistics;
 import me.cortex.voxy.client.VoxyClient;
 import me.cortex.voxy.client.config.VoxyConfig;
@@ -419,6 +420,8 @@ public class VoxyRenderSystem {
 
         float far = 16*3000;
 
+        boolean zZeroToOne = RenderSystem.getDevice().isZZeroToOne();
+
         /* jank way of just modifying the base raw
         if (true) {
             return new Matrix4f(base)
@@ -428,8 +431,8 @@ public class VoxyRenderSystem {
 
         return extraProjection.mulLocal(
                 new Matrix4f(rawMCProj)
-                .m22((far + near) / (near - far))
-                .m32((far+far) * near / (near - far))
+                .m22((zZeroToOne ? far : (far + near)) / (near - far))
+                .m32((zZeroToOne ? far : (far+far)) * near / (near - far))
         );
     }
 


### PR DESCRIPTION
This is an attempt to begin working on possible issues that may affect voxy's compatibility with Longview (see https://github.com/EnnuiL/longview/issues/6 for more), starting by ensuring that the projection matrix that is calculated by voxy accounts for a Blaze3D backend that has its Z range from 0 to 1.

Now, the issues that have been fixed by this? Unknown. Disabling Reverse-Z on Longview and leaving only the Z-Zero-to-One part enabled does not show any issues with stock voxy, and the issues that manifest with Longview completely on do not appear to get any better. Still, I feel like precaution is something that can be very important here