### PR TITLE
fix block light packing in LoD mip

### DIFF
--- a/src/main/java/me/cortex/voxy/common/world/other/Mipper.java
+++ b/src/main/java/me/cortex/voxy/common/world/other/Mipper.java
@@ -74,10 +74,10 @@ public class Mipper {
                     (Mapper.getLightId(I100) & 0xF0) + (Mapper.getLightId(I101) & 0xF0) + (Mapper.getLightId(I110) & 0xF0) + (Mapper.getLightId(I111) & 0xF0);
             int skyLight = (Mapper.getLightId(I000) & 0x0F) + (Mapper.getLightId(I001) & 0x0F) + (Mapper.getLightId(I010) & 0x0F) + (Mapper.getLightId(I011) & 0x0F) +
                     (Mapper.getLightId(I100) & 0x0F) + (Mapper.getLightId(I101) & 0x0F) + (Mapper.getLightId(I110) & 0x0F) + (Mapper.getLightId(I111) & 0x0F);
-            blockLight = blockLight / 8;
+            blockLight = (blockLight / 8) & 0xF0;
             skyLight = (int) Math.ceil((double) skyLight / 8);
 
-            return withLight(I111, (blockLight << 4) | skyLight);
+            return withLight(I111, blockLight | skyLight);
         }
     }
 }


### PR DESCRIPTION
I believe the light offset is incorrect during mip generation, which causes block light to be packed into the wrong bits and corrupt the final light value. It is hidden when skylight is 15, but becomes clearly visible when skylight is lower. This fixes the issue shown below, but I haven't yet confirmed whether it affects behavior elsewhere. Screenshots use block light 5 & sky light 0.

Before:
<img width="1920" height="1051" alt="2026-04-19_21 29 01" src="https://github.com/user-attachments/assets/f2bee4a9-dab2-4dfa-9a77-72e6d8d5d5fc" />

After:
<img width="1920" height="1051" alt="2026-04-19_21 30 08" src="https://github.com/user-attachments/assets/f1be8746-9d7c-444f-a9de-e86efd238375" />
