### PR TITLE
fix X-axis face occlusion

### DIFF
--- a/src/main/java/me/cortex/voxy/client/core/rendering/building/RenderDataFactory.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/building/RenderDataFactory.java
@@ -1024,7 +1024,7 @@ public class RenderDataFactory {
                         long meta = this.modelMan.getModelMetadataFromClientId(this.modelMan.getModelId(Mapper.getBlockId(neighborId)));
                         if (ModelQueries.isFullyOpaque(meta)) {
                             oki = false;
-                        } else if (CHECK_NEIGHBOR_FACE_OCCLUSION && ModelQueries.faceOccludes(meta, (2 << 1) | (1 - 1))) {
+                        } else if (CHECK_NEIGHBOR_FACE_OCCLUSION && ModelQueries.faceOccludes(meta, (2 << 1) | (1 - 0))) {
                             //TODO check self occlsion
                             oki = false;
                         }
@@ -1046,7 +1046,7 @@ public class RenderDataFactory {
                         long meta = this.modelMan.getModelMetadataFromClientId(this.modelMan.getModelId(Mapper.getBlockId(neighborId)));
                         if (ModelQueries.isFullyOpaque(meta)) {
                             oki = false;
-                        } else if (CHECK_NEIGHBOR_FACE_OCCLUSION && ModelQueries.faceOccludes(meta, (2 << 1) | (1 - 0))) {
+                        } else if (CHECK_NEIGHBOR_FACE_OCCLUSION && ModelQueries.faceOccludes(meta, (2 << 1) | (1 - 1))) {
                             //TODO check self occlsion
                             oki = false;
                         }


### PR DESCRIPTION
This is a very small issue affecting more detailed builds but the occlusion check is flipped. Other functions use (1 - side) which is correct but not `generateXOuterOpaqueGeometry`.

Before:
<img width="639" height="297" alt="2026-04-21_13 40 12" src="https://github.com/user-attachments/assets/181da16c-5522-44fa-847c-827d81d75531" />

After:
<img width="639" height="297" alt="2026-04-21_13 40 39" src="https://github.com/user-attachments/assets/2f25d737-1274-404c-8f30-285506bf1a72" />
