### PR TITLE
fix same-model non-opaque face culling

### DIFF
--- a/src/main/java/me/cortex/voxy/client/core/rendering/building/RenderDataFactory.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/building/RenderDataFactory.java
@@ -353,7 +353,8 @@ public class RenderDataFactory {
     private static final long LM = (0xFFL<<55);
 
     private static boolean shouldMeshNonOpaqueBlockFace(int face, long quad, long meta, long neighborQuad, long neighborMeta) {
-        if (((quad^neighborQuad)&(0xFFFFL<<26))==0 && (DISABLE_CULL_SAME_OCCLUDES || (ModelQueries.cullsSame(meta)||ModelQueries.faceOccludes(meta, face)))) return false;//This is a hack, if the neigbor and this are the same, dont mesh the face// TODO: FIXME
+        if (((quad^neighborQuad)&(0xFFFFL<<26))==0 && ModelQueries.faceExists(neighborMeta, face ^ 1)
+                && (DISABLE_CULL_SAME_OCCLUDES || ModelQueries.cullsSame(meta))) return false;//This is a hack, if the neigbor and this are the same, dont mesh the face// TODO: FIXME
         if (!ModelQueries.faceExists(meta, face)) return false;//Dont mesh if no face
         if (ModelQueries.faceCanBeOccluded(meta, face)) //TODO: maybe enable this
           if (ModelQueries.faceOccludes(neighborMeta, face^1)) return false;


### PR DESCRIPTION
This change makes it so models require the same-model neighbor's opposite face to exist before culling. It is a strictly less aggressive cull strategy (anything that was not culled before remains unculled). Also worth noting: `DISABLE_CULL_SAME_OCCLUDES` appears to do the opposite of what its name suggests and some of the comments may need updating.

Before:
<img width="1920" height="1051" alt="2026-04-25_13 47 05" src="https://github.com/user-attachments/assets/5d072036-e0db-414b-b189-74a6a657472e" />

After:
<img width="1920" height="1051" alt="image" src="https://github.com/user-attachments/assets/6a4088fc-2c5b-4785-9025-d634596e74cd" />