### PR TITLE
Added config option to toggle debug messages in chat

### DIFF
--- a/src/main/java/me/cortex/voxy/client/config/VoxyConfig.java
+++ b/src/main/java/me/cortex/voxy/client/config/VoxyConfig.java
@@ -34,6 +34,7 @@ public class VoxyConfig {
     public boolean useEnvironmentalFog = true;
     public boolean dontUseSodiumBuilderThreads = false;
     public String ssaoMode;
+    public boolean chatLoggingEnabled = true;
 
     public SSAO.SSAOMode getSSAOMode() {
         if (this.ssaoMode == null) return SSAO.SSAOMode.AUTO;

--- a/src/main/java/me/cortex/voxy/client/config/VoxyConfigMenu.java
+++ b/src/main/java/me/cortex/voxy/client/config/VoxyConfigMenu.java
@@ -75,6 +75,11 @@ public class VoxyConfigMenu implements ConfigEntryPoint {
                                         "voxy:ingest_enabled",
                                         Component.translatable("voxy.config.general.ingest"),
                                         ()->CFG.ingestEnabled, v->CFG.ingestEnabled=v)
+                        ), new Group(
+                                new BoolOption(
+                                        "voxy:logging_enabled",
+                                        Component.translatable("voxy.config.general.chat_logging"),
+                                        ()->CFG.chatLoggingEnabled, v->CFG.chatLoggingEnabled =v)
                         )
                 ).setEnabler("voxy:enabled"),
                 new Page(Component.translatable("voxy.config.rendering"),

--- a/src/main/java/me/cortex/voxy/common/Logger.java
+++ b/src/main/java/me/cortex/voxy/common/Logger.java
@@ -1,5 +1,6 @@
 package me.cortex.voxy.common;
 
+import me.cortex.voxy.client.config.VoxyConfig;
 import me.cortex.voxy.commonImpl.VoxyCommon;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
@@ -58,6 +59,9 @@ public class Logger {
     }
 
     public static void showInHUD(String msg) {
+        if (!VoxyConfig.CONFIG.chatLoggingEnabled) {
+            return;
+        }
         var instance = Minecraft.getInstance();
         if (instance != null) {
             instance.executeIfPossible(() -> {

--- a/src/main/resources/assets/voxy/lang/en_us.json
+++ b/src/main/resources/assets/voxy/lang/en_us.json
@@ -32,5 +32,8 @@
   "voxy.config.general.render_fog.tooltip": "Enables or disables render fog effect",
 
   "voxy.config.general.ssao_mode": "SSAO Mode",
-  "voxy.config.general.ssao_mode.tooltip": "The mode used for screenspace ambient occlusion (Auto attempts to pick the best option while reducing performance impact)"
+  "voxy.config.general.ssao_mode.tooltip": "The mode used for screenspace ambient occlusion (Auto attempts to pick the best option while reducing performance impact)",
+
+  "voxy.config.general.chat_logging": "Show debug messages",
+  "voxy.config.general.chat_logging.tooltip": "Enables or disables debug messages such as warnings and errors from appearing in the chat. Debug messages will still appear in log files."
 }


### PR DESCRIPTION
Title pretty much sums it up.

While the debug messages can be pretty handy for devs, for regular players it could easily become just a nuisance.
All I've done is simply add a new boolean config option that `Logger.showInHUD()` checks before sending its message in chat.