### PR TITLE
Add configurable LOD thread limits for load, ingest, mesh, and save

### DIFF
--- a/src/main/java/me/cortex/voxy/client/VoxyClientInstance.java
+++ b/src/main/java/me/cortex/voxy/client/VoxyClientInstance.java
@@ -2,6 +2,7 @@ package me.cortex.voxy.client;
 
 import me.cortex.voxy.client.compat.FlashbackCompat;
 import me.cortex.voxy.client.config.VoxyConfig;
+import me.cortex.voxy.client.core.IGetVoxyRenderSystem;
 import me.cortex.voxy.client.mixin.sodium.AccessorSodiumWorldRenderer;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.StorageConfigUtil;
@@ -38,6 +39,16 @@ public class VoxyClientInstance extends VoxyInstance {
         this.basePath = path;
         this.storageConfig = StorageConfigUtil.getCreateStorageConfig(Config.class, c->c.version==1&&c.sectionStorageConfig!=null, ()->DEFAULT_STORAGE_CONFIG, path).sectionStorageConfig;
         this.updateDedicatedThreads();
+        this.updateLodThreadLimits();
+    }
+
+    public void updateLodThreadLimits() {
+        var config = VoxyConfig.CONFIG;
+        super.updateLodThreadLimits(config.lodIngestThreads, config.lodSaveThreads, config.lodLoadThreads);
+        var renderSystem = IGetVoxyRenderSystem.getNullable();
+        if (renderSystem != null) {
+            renderSystem.updateLodThreadLimits();
+        }
     }
 
     @Override

--- a/src/main/java/me/cortex/voxy/client/config/VoxyConfig.java
+++ b/src/main/java/me/cortex/voxy/client/config/VoxyConfig.java
@@ -29,6 +29,10 @@ public class VoxyConfig implements OptionStorage<VoxyConfig> {
     public boolean ingestEnabled = true;
     public int sectionRenderDistance = 16;
     public int serviceThreads = (int) Math.max(CpuLayout.getCoreCount()/1.5, 1);
+    public int lodLoadThreads = Math.max(1, CpuLayout.getCoreCount() / 4);
+    public int lodIngestThreads = Math.max(1, CpuLayout.getCoreCount() / 4);
+    public int lodMeshThreads = Math.max(1, CpuLayout.getCoreCount() / 4);
+    public int lodSaveThreads = 1;
     public float subDivisionSize = 64;
     public boolean useEnvironmentalFog = true;
     public boolean dontUseSodiumBuilderThreads = false;
@@ -40,6 +44,7 @@ public class VoxyConfig implements OptionStorage<VoxyConfig> {
                 try (FileReader reader = new FileReader(path.toFile())) {
                     var conf = GSON.fromJson(reader, VoxyConfig.class);
                     if (conf != null) {
+                        conf.applyDefaults();
                         conf.save();
                         return conf;
                     } else {
@@ -87,5 +92,24 @@ public class VoxyConfig implements OptionStorage<VoxyConfig> {
 
     public boolean isRenderingEnabled() {
         return VoxyCommon.isAvailable() && this.enabled && this.enableRendering;
+    }
+
+    private void applyDefaults() {
+        int cores = CpuLayout.getCoreCount();
+        if (this.serviceThreads <= 0) {
+            this.serviceThreads = (int) Math.max(cores / 1.5, 1);
+        }
+        if (this.lodLoadThreads <= 0) {
+            this.lodLoadThreads = Math.max(1, cores / 4);
+        }
+        if (this.lodIngestThreads <= 0) {
+            this.lodIngestThreads = Math.max(1, cores / 4);
+        }
+        if (this.lodMeshThreads <= 0) {
+            this.lodMeshThreads = Math.max(1, cores / 4);
+        }
+        if (this.lodSaveThreads <= 0) {
+            this.lodSaveThreads = 1;
+        }
     }
 }

--- a/src/main/java/me/cortex/voxy/client/config/VoxyConfigPageSodium.java
+++ b/src/main/java/me/cortex/voxy/client/config/VoxyConfigPageSodium.java
@@ -1,8 +1,8 @@
 package me.cortex.voxy.client.config;
 
 import com.google.common.collect.ImmutableList;
-import me.cortex.voxy.client.RenderStatistics;
 import me.cortex.voxy.client.VoxyClientInstance;
+import me.cortex.voxy.client.RenderStatistics;
 import me.cortex.voxy.client.core.IGetVoxyRenderSystem;
 import me.cortex.voxy.common.util.cpu.CpuLayout;
 import me.cortex.voxy.commonImpl.VoxyCommon;
@@ -18,6 +18,21 @@ public abstract class VoxyConfigPageSodium {
     private VoxyConfigPageSodium(){}
 
     public static OptionPage voxyOptionPage = null;
+
+    private static int maxThreadSlider() {
+        if (CpuLayout.CORES != null) {
+            return CpuLayout.CORES.length;
+        }
+        return Runtime.getRuntime().availableProcessors();
+    }
+
+    private static void applyLodThreadLimits() {
+        var instance = VoxyCommon.getInstance();
+        if (instance instanceof VoxyClientInstance clientInstance) {
+            clientInstance.updateLodThreadLimits();
+        }
+        VoxyConfig.CONFIG.save();
+    }
 
     public static OptionPage page() {
         List<OptionGroup> groups = new ArrayList<>();
@@ -57,8 +72,7 @@ public abstract class VoxyConfigPageSodium {
                         .setName(Component.translatable("voxy.config.general.serviceThreads"))
                         .setTooltip(Component.translatable("voxy.config.general.serviceThreads.tooltip"))
                         .setControl(opt->new SliderControl(opt, 1,
-                                CpuLayout.CORES.length, //Just do core size as max
-                                //Runtime.getRuntime().availableProcessors(),//Note: this is threads not cores, the default value is half the core count, is fine as this should technically be the limit but CpuLayout.CORES.length is more realistic
+                                maxThreadSlider(),
                                 1, v->Component.literal(Integer.toString(v))))
                         .setBinding((s, v)->{
                             s.serviceThreads = v;
@@ -88,6 +102,50 @@ public abstract class VoxyConfigPageSodium {
                         .setTooltip(Component.translatable("voxy.config.general.ingest.tooltip"))
                         .setControl(TickBoxControl::new)
                         .setBinding((s, v) -> s.ingestEnabled = v, s -> s.ingestEnabled)
+                        .setImpact(OptionImpact.MEDIUM)
+                        .build()
+                ).build()
+        );
+
+        groups.add(OptionGroup.createBuilder()
+                .add(OptionImpl.createBuilder(int.class, storage)
+                        .setName(Component.translatable("voxy.config.lod.loadThreads"))
+                        .setTooltip(Component.translatable("voxy.config.lod.loadThreads.tooltip"))
+                        .setControl(opt->new SliderControl(opt, 1, maxThreadSlider(), 1, v->Component.literal(Integer.toString(v))))
+                        .setBinding((s, v)->{
+                            s.lodLoadThreads = v;
+                            applyLodThreadLimits();
+                        }, s -> s.lodLoadThreads)
+                        .setImpact(OptionImpact.HIGH)
+                        .build()
+                ).add(OptionImpl.createBuilder(int.class, storage)
+                        .setName(Component.translatable("voxy.config.lod.ingestThreads"))
+                        .setTooltip(Component.translatable("voxy.config.lod.ingestThreads.tooltip"))
+                        .setControl(opt->new SliderControl(opt, 1, maxThreadSlider(), 1, v->Component.literal(Integer.toString(v))))
+                        .setBinding((s, v)->{
+                            s.lodIngestThreads = v;
+                            applyLodThreadLimits();
+                        }, s -> s.lodIngestThreads)
+                        .setImpact(OptionImpact.HIGH)
+                        .build()
+                ).add(OptionImpl.createBuilder(int.class, storage)
+                        .setName(Component.translatable("voxy.config.lod.meshThreads"))
+                        .setTooltip(Component.translatable("voxy.config.lod.meshThreads.tooltip"))
+                        .setControl(opt->new SliderControl(opt, 1, maxThreadSlider(), 1, v->Component.literal(Integer.toString(v))))
+                        .setBinding((s, v)->{
+                            s.lodMeshThreads = v;
+                            applyLodThreadLimits();
+                        }, s -> s.lodMeshThreads)
+                        .setImpact(OptionImpact.HIGH)
+                        .build()
+                ).add(OptionImpl.createBuilder(int.class, storage)
+                        .setName(Component.translatable("voxy.config.lod.saveThreads"))
+                        .setTooltip(Component.translatable("voxy.config.lod.saveThreads.tooltip"))
+                        .setControl(opt->new SliderControl(opt, 1, maxThreadSlider(), 1, v->Component.literal(Integer.toString(v))))
+                        .setBinding((s, v)->{
+                            s.lodSaveThreads = v;
+                            applyLodThreadLimits();
+                        }, s -> s.lodSaveThreads)
                         .setImpact(OptionImpact.MEDIUM)
                         .build()
                 ).build()

--- a/src/main/java/me/cortex/voxy/client/core/VoxyRenderSystem.java
+++ b/src/main/java/me/cortex/voxy/client/core/VoxyRenderSystem.java
@@ -143,6 +143,8 @@ public class VoxyRenderSystem {
                 this.setRenderDistance(VoxyConfig.CONFIG.sectionRenderDistance);
             }
 
+            this.updateLodThreadLimits();
+
             this.chunkBoundRenderer = new ChunkBoundRenderer(this.pipeline);
 
             Logger.info("Voxy render system created with " + geometryCapacity + " geometry capacity, using pipeline '" + this.pipeline.getClass().getSimpleName() + "' with renderer '" + sectionRenderer.getClass().getSimpleName() + "'");
@@ -162,6 +164,10 @@ public class VoxyRenderSystem {
         }
     }
 
+
+    public void updateLodThreadLimits() {
+        this.renderGen.applyThreadLimit(VoxyConfig.CONFIG.lodMeshThreads);
+    }
 
     public Viewport<?> setupViewport(ChunkRenderMatrices matrices, FogParameters fogParameters, double cameraX, double cameraY, double cameraZ) {
         var viewport = this.getViewport();

--- a/src/main/java/me/cortex/voxy/client/core/rendering/building/RenderGenerationService.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/building/RenderGenerationService.java
@@ -366,4 +366,9 @@ public class RenderGenerationService {
     public int getTaskCount() {
         return this.taskQueueCount.get();
     }
+
+    public void applyThreadLimit(int threads) {
+        this.service.setMaxConcurrent(threads);
+        this.service.setWeight(Math.max(1, threads));
+    }
 }

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinLevelRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinLevelRenderer.java
@@ -92,5 +92,6 @@ public abstract class MixinLevelRenderer implements IGetVoxyRenderSystem {
             }
         }
         instance.updateDedicatedThreads();
+        instance.updateLodThreadLimits();
     }
 }

--- a/src/main/java/me/cortex/voxy/common/thread/Service.java
+++ b/src/main/java/me/cortex/voxy/common/thread/Service.java
@@ -4,17 +4,20 @@ import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.util.Pair;
 
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 public class Service {
     private final PerThreadContextExecutor executor;
     private final ServiceManager sm;
-    final long weight;
+    volatile long weight;
     final String name;
     final BooleanSupplier limiter;
 
     private final Semaphore tasks = new Semaphore(0);
+    private final AtomicInteger activeJobs = new AtomicInteger();
+    private volatile int maxConcurrent = Integer.MAX_VALUE;
     private volatile boolean isLive = true;
     private volatile boolean isStopping = false;
 
@@ -25,6 +28,29 @@ public class Service {
         this.limiter = limiter;
 
         this.executor = new PerThreadContextExecutor(ctxSupplier, e->sm.handleException(this, e));
+    }
+
+    public void setMaxConcurrent(int max) {
+        this.maxConcurrent = Math.max(1, max);
+    }
+
+    public void setWeight(long weight) {
+        this.weight = Math.max(1, weight);
+    }
+
+    public int getActiveJobs() {
+        return this.activeJobs.get();
+    }
+
+    public int getMaxConcurrent() {
+        return this.maxConcurrent;
+    }
+
+    boolean canAcceptJobs() {
+        if (this.activeJobs.get() >= this.maxConcurrent) {
+            return false;
+        }
+        return this.limiter == null || this.limiter.getAsBoolean();
     }
 
     public void execute() {
@@ -44,8 +70,17 @@ public class Service {
             //Failed to get the job, probably due to a race condition
             return false;
         }
-        if (!this.executor.run()) {//Run the job
-            throw new IllegalStateException("Executor failed to run");
+        if (!this.canAcceptJobs()) {
+            this.tasks.release();
+            return false;
+        }
+        this.activeJobs.incrementAndGet();
+        try {
+            if (!this.executor.run()) {//Run the job
+                throw new IllegalStateException("Executor failed to run");
+            }
+        } finally {
+            this.activeJobs.decrementAndGet();
         }
         return true;
     }

--- a/src/main/java/me/cortex/voxy/common/thread/ServiceManager.java
+++ b/src/main/java/me/cortex/voxy/common/thread/ServiceManager.java
@@ -83,7 +83,7 @@ public class ServiceManager {
                     continue outer;//We need to refetch the array and start over
                 }
                 boolean sc = c--<=0;
-                if (service.limiter!=null && !service.limiter.getAsBoolean()) {
+                if (!service.canAcceptJobs()) {
                     skipMsk |= 1L<<i;
                     continue;
                 }
@@ -97,7 +97,7 @@ public class ServiceManager {
 
             for (int i = 0; i < services.length; i++) {
                 var service = services[(i+shiftFactor)%services.length];
-                if (service.limiter!=null && (((skipMsk&(1L<<i))!=0)|| !service.limiter.getAsBoolean())) {
+                if (((skipMsk&(1L<<i))!=0) || !service.canAcceptJobs()) {
                     skipMsk |= 1L<<i;
                     continue;
                 }

--- a/src/main/java/me/cortex/voxy/common/world/ActiveSectionTracker.java
+++ b/src/main/java/me/cortex/voxy/common/world/ActiveSectionTracker.java
@@ -144,7 +144,12 @@ public class ActiveSectionTracker {
                         WorldEngine.getZ(key),
                         this);
 
-                status = this.loader.load(section);
+                SectionLoadLimiter.acquire();
+                try {
+                    status = this.loader.load(section);
+                } finally {
+                    SectionLoadLimiter.release();
+                }
 
                 if (status < 0) {
                     //TODO: Instead if throwing an exception do something better, like attempting to regen

--- a/src/main/java/me/cortex/voxy/common/world/SectionLoadLimiter.java
+++ b/src/main/java/me/cortex/voxy/common/world/SectionLoadLimiter.java
@@ -1,0 +1,34 @@
+package me.cortex.voxy.common.world;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class SectionLoadLimiter {
+    private static volatile int maxConcurrent = 2;
+    private static final AtomicInteger active = new AtomicInteger();
+
+    private SectionLoadLimiter() {}
+
+    public static void setMaxConcurrent(int max) {
+        maxConcurrent = Math.max(1, max);
+    }
+
+    public static int getMaxConcurrent() {
+        return maxConcurrent;
+    }
+
+    public static int getActiveCount() {
+        return active.get();
+    }
+
+    public static void acquire() {
+        while (active.get() >= maxConcurrent) {
+            Thread.onSpinWait();
+            Thread.yield();
+        }
+        active.incrementAndGet();
+    }
+
+    public static void release() {
+        active.decrementAndGet();
+    }
+}

--- a/src/main/java/me/cortex/voxy/common/world/service/SectionSavingService.java
+++ b/src/main/java/me/cortex/voxy/common/world/service/SectionSavingService.java
@@ -88,4 +88,9 @@ public class SectionSavingService {
     public int getTaskCount() {
         return this.service.numJobs();
     }
+
+    public void applyThreadLimit(int threads) {
+        this.service.setMaxConcurrent(threads);
+        this.service.setWeight(Math.max(1, threads));
+    }
 }

--- a/src/main/java/me/cortex/voxy/common/world/service/VoxelIngestService.java
+++ b/src/main/java/me/cortex/voxy/common/world/service/VoxelIngestService.java
@@ -175,6 +175,11 @@ public class VoxelIngestService {
         return this.service.numJobs();
     }
 
+    public void applyThreadLimit(int threads) {
+        this.service.setMaxConcurrent(threads);
+        this.service.setWeight(Math.max(1, threads));
+    }
+
     public void shutdown() {
         this.service.shutdown();
     }

--- a/src/main/java/me/cortex/voxy/commonImpl/VoxyInstance.java
+++ b/src/main/java/me/cortex/voxy/commonImpl/VoxyInstance.java
@@ -5,6 +5,7 @@ import me.cortex.voxy.common.config.section.SectionStorage;
 import me.cortex.voxy.common.thread.ServiceManager;
 import me.cortex.voxy.common.thread.UnifiedServiceThreadPool;
 import me.cortex.voxy.common.util.MemoryBuffer;
+import me.cortex.voxy.common.world.SectionLoadLimiter;
 import me.cortex.voxy.common.world.WorldEngine;
 import me.cortex.voxy.common.world.service.SectionSavingService;
 import me.cortex.voxy.common.world.service.VoxelIngestService;
@@ -66,6 +67,12 @@ public abstract class VoxyInstance {
 
     public void updateDedicatedThreads() {
         this.setNumThreads(3);
+    }
+
+    public void updateLodThreadLimits(int ingestThreads, int saveThreads, int loadThreads) {
+        this.ingestService.applyThreadLimit(ingestThreads);
+        this.savingService.applyThreadLimit(saveThreads);
+        SectionLoadLimiter.setMaxConcurrent(loadThreads);
     }
 
     protected ImportManager createImportManager() {

--- a/src/main/resources/assets/voxy/lang/en_us.json
+++ b/src/main/resources/assets/voxy/lang/en_us.json
@@ -8,7 +8,19 @@
   "voxy.config.general.enabled.tooltip": "Fully enables or disables voxy",
 
   "voxy.config.general.serviceThreads": "Service threads",
-  "voxy.config.general.serviceThreads.tooltip": "Number of threads the ServiceThreadPool can use",
+  "voxy.config.general.serviceThreads.tooltip": "Total number of worker threads in the Voxy thread pool. Use LOD thread settings below to limit how many threads each task type can use at once.",
+
+  "voxy.config.lod.loadThreads": "LOD load threads",
+  "voxy.config.lod.loadThreads.tooltip": "Maximum number of LOD sections that can be loaded from storage at the same time",
+
+  "voxy.config.lod.ingestThreads": "LOD ingest threads",
+  "voxy.config.lod.ingestThreads.tooltip": "Maximum number of parallel chunk-to-LOD conversion jobs",
+
+  "voxy.config.lod.meshThreads": "LOD mesh threads",
+  "voxy.config.lod.meshThreads.tooltip": "Maximum number of parallel LOD mesh generation jobs for rendering",
+
+  "voxy.config.lod.saveThreads": "LOD save threads",
+  "voxy.config.lod.saveThreads.tooltip": "Maximum number of parallel LOD section save jobs to storage",
 
   "voxy.config.general.useSodiumBuilder": "Use sodium threads",
   "voxy.config.general.useSodiumBuilder.tooltip": "Uses sodium builder threads as part of voxys thread pool, can reduce stuttering and lag when moving quickly at high render distance",

--- a/src/main/resources/assets/voxy/lang/ru_ru.json
+++ b/src/main/resources/assets/voxy/lang/ru_ru.json
@@ -1,0 +1,48 @@
+{
+  "voxy.config.title": "Voxy",
+
+  "voxy.config.general": "Общие",
+  "voxy.config.rendering": "Рендеринг",
+
+  "voxy.config.general.enabled": "Включить Voxy",
+  "voxy.config.general.enabled.tooltip": "Полностью включает или отключает Voxy",
+
+  "voxy.config.general.serviceThreads": "Рабочие потоки",
+  "voxy.config.general.serviceThreads.tooltip": "Общее количество рабочих потоков пула Voxy. Ниже можно ограничить, сколько потоков одновременно использует каждый тип задач LOD.",
+
+  "voxy.config.lod.loadThreads": "Потоки загрузки LOD",
+  "voxy.config.lod.loadThreads.tooltip": "Максимальное число одновременных загрузок секций LOD из хранилища",
+
+  "voxy.config.lod.ingestThreads": "Потоки инжеста LOD",
+  "voxy.config.lod.ingestThreads.tooltip": "Максимальное число параллельных задач конвертации чанков в LOD",
+
+  "voxy.config.lod.meshThreads": "Потоки мешинга LOD",
+  "voxy.config.lod.meshThreads.tooltip": "Максимальное число параллельных задач генерации мешей LOD для рендеринга",
+
+  "voxy.config.lod.saveThreads": "Потоки сохранения LOD",
+  "voxy.config.lod.saveThreads.tooltip": "Максимальное число параллельных задач сохранения секций LOD в хранилище",
+
+  "voxy.config.general.useSodiumBuilder": "Использовать потоки Sodium",
+  "voxy.config.general.useSodiumBuilder.tooltip": "Использует потоки сборщика Sodium как часть пула потоков Voxy — может уменьшить фризы при быстром движении на большой дистанции прорисовки",
+
+  "voxy.config.general.ingest": "Инжест чанков",
+  "voxy.config.general.ingest.tooltip": "Включает или отключает конвертацию новых чанков в LOD",
+
+  "voxy.config.general.rendering": "Рендеринг Voxy",
+  "voxy.config.general.rendering.tooltip": "Включает или отключает рендеринг Voxy",
+
+  "voxy.config.general.subDivisionSize": "Размер подразделения (пикс²)",
+  "voxy.config.general.subDivisionSize.tooltip": "Максимальный размер AABB в экранном пространстве (в пикселях²) перед переходом к более мелким LOD (меньше — выше качество)",
+
+  "voxy.config.general.renderDistance": "Дистанция прорисовки",
+  "voxy.config.general.renderDistance.tooltip": "Дистанция прорисовки Voxy в чанках",
+
+  "voxy.config.general.environmental_fog": "Включить средовой туман",
+  "voxy.config.general.environmental_fog.tooltip": "Включает или отключает рендеринг средового тумана Voxy",
+
+  "voxy.config.general.render_fog": "Включить туман рендера",
+  "voxy.config.general.render_fog.tooltip": "Включает или отключает эффект тумана рендера",
+
+  "voxy.config.general.render_statistics": "Статистика рендера",
+  "voxy.config.general.render_statistics.tooltip": "Показывать статистику рендера в меню F3 — полезно для отладки"
+}


### PR DESCRIPTION
## Summary
- Adds separate CPU thread limits for LOD loading, chunk ingest, mesh generation, and section saving
- Settings are exposed in Sodium → Voxy and applied live without restart
- Adds Russian localization for the new options

## Motivation
Previously Voxy used a single service thread pool with hardcoded service weights, which could saturate all CPU cores during LOD work. These settings let users cap parallelism per pipeline stage.

## Test plan
- [x] Built successfully with Gradle
- [x] Verified settings appear in Sodium → Voxy
- [x] Verified changing thread limits affects LOD workload in-game