### PR TITLE
Load the LOD world engine off the render thread on level reload (fix join freeze)

### DIFF
--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinLevelRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinLevelRenderer.java
@@ -9,6 +9,7 @@ import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.world.WorldEngine;
 import me.cortex.voxy.commonImpl.VoxyCommon;
 import me.cortex.voxy.commonImpl.WorldIdentifier;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.LevelRenderer;
 import org.jetbrains.annotations.Nullable;
@@ -23,6 +24,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class MixinLevelRenderer implements IGetVoxyRenderSystem {
     @Shadow private @Nullable ClientLevel level;
     @Unique private VoxyRenderSystem renderer;
+
+    // Bumped on every shutdown/create (all on the render thread). An in-flight async engine
+    // load captures the value at start and re-checks it before installing the renderer, so a
+    // load that has been superseded by a level change / disconnect / reload is discarded.
+    @Unique private int voxy$loadGeneration;
 
     @Override
     public VoxyRenderSystem voxy$getRenderSystem() {
@@ -51,6 +57,8 @@ public abstract class MixinLevelRenderer implements IGetVoxyRenderSystem {
 
     @Override
     public void voxy$shutdownRenderer() {
+        // invalidate any in-flight async engine load
+        this.voxy$loadGeneration++;
         if (this.renderer != null) {
             this.renderer.shutdown();
             this.renderer = null;
@@ -78,13 +86,55 @@ public abstract class MixinLevelRenderer implements IGetVoxyRenderSystem {
             Logger.info("Not creating renderer due to null instance");
             return;
         }
-        WorldEngine world = WorldIdentifier.ofEngine(this.level);
-        if (world == null) {
-            Logger.error("Null world selected");
+
+        // Opening the WorldEngine (RocksDB open + Mapper/palette load) reads the on-disk LOD
+        // store and can take many seconds for a large store. Done here on the render thread
+        // (inside LevelRenderer.allChanged) it freezes the client on join. So build the engine
+        // on a background thread, then install the GL-bound VoxyRenderSystem back on the render
+        // thread once the engine is ready.
+        final ClientLevel capturedLevel = this.level;
+        final VoxyClientInstance capturedInstance = instance;
+        final int generation = ++this.voxy$loadGeneration;
+
+        Thread loader = new Thread(() -> {
+            WorldEngine world;
+            try {
+                world = WorldIdentifier.ofEngine(capturedLevel);
+            } catch (Throwable e) {
+                Logger.error("Async Voxy engine load failed", e);
+                return;
+            }
+            if (world == null) {
+                Logger.error("Null world selected");
+                return;
+            }
+            Minecraft.getInstance().execute(() ->
+                    this.voxy$installRenderer(world, capturedInstance, capturedLevel, generation));
+        }, "Voxy-EngineLoader");
+        loader.setDaemon(true);
+        loader.start();
+    }
+
+    // Runs on the render thread (GL context current) after the engine has been built off-thread.
+    @Unique
+    private void voxy$installRenderer(WorldEngine world, VoxyClientInstance capturedInstance,
+                                      ClientLevel capturedLevel, int generation) {
+        if (generation != this.voxy$loadGeneration) {
+            // superseded by a shutdown / newer load; leave the engine cached (Voxy's idle-world
+            // cleaner frees it if unused) and do nothing.
+            return;
+        }
+        if (this.level != capturedLevel || this.level == null) {
+            return;
+        }
+        if (this.renderer != null) {
+            return;
+        }
+        if (VoxyCommon.getInstance() != capturedInstance) {
             return;
         }
         try {
-            this.renderer = new VoxyRenderSystem(world, instance.getServiceManager());
+            this.renderer = new VoxyRenderSystem(world, capturedInstance.getServiceManager());
         } catch (RuntimeException e) {
             if (IrisUtil.irisShaderPackEnabled()) {
                 IrisUtil.disableIrisShaders();
@@ -92,6 +142,6 @@ public abstract class MixinLevelRenderer implements IGetVoxyRenderSystem {
                 throw e;
             }
         }
-        instance.updateDedicatedThreads();
+        capturedInstance.updateDedicatedThreads();
     }
 }


### PR DESCRIPTION
### Summary
`LevelRenderer.allChanged` builds the Voxy renderer synchronously, which opens and indexes the per-world LOD store (RocksDB open + `Mapper`/palette load) **on the render thread**. For a large store this freezes the client for several seconds on every join / dimension change.

### Fix
Build the `WorldEngine` on a background thread, then create the GL-bound `VoxyRenderSystem` back on the render thread once it's ready. A generation counter (bumped on every shutdown/create, all on the render thread) lets an in-flight load detect that it has been superseded by a level change / disconnect / reload and discard itself safely. The GL object is still created on the render thread; only the disk I/O moves off it.

### Scope / testing
One file (`MixinLevelRenderer`). Tested on MC 26.1.2 with a large LOD store (alongside VoxyServer): the join freeze is eliminated; LODs fill in a moment later as the engine finishes loading.

### Note for maintainer
`VoxyInstance.getOrCreate` still holds its `StampedLock` write lock across the build - now off the render thread, so it no longer freezes rendering, but it can briefly block other `getOrCreate` callers (e.g. ingest) during the first load. Relaxing that lock is a deeper change left out of scope here.

---
Happy to discuss any of this - you can reach me on my Discord: https://discord.gg/2ZxzbCzAHe