### PR TITLE
feat: ported to 26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,27 +7,27 @@ org.gradle.daemon = false
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=26.1.2
-loader_version=0.18.6
-loom_version=1.15-SNAPSHOT
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.16-SNAPSHOT
 
 # Fabric API
-fabric_api_version=0.148.0+26.1.2
-sodium_version_modrinth=mc26.1.2-0.8.12-fabric
+fabric_api_version=0.153.0+26.2
+sodium_version_modrinth=mc26.2-0.9.0-fabric
 sodium_extra_allows=0.8.9 0.8.10 0.8.11 0.8.12
 
-modmenu_version=18.0.0-alpha.8
-lithium_version=mc26.1.2-0.24.2-fabric
+modmenu_version=20.0.0-beta.4
+lithium_version=mc26.2-0.25.0-fabric
 
-iris_version=1.10.9+26.1-fabric
+iris_version=1.11.1+26.2-fabric
 
-chunky_version=DCgX52a5
-vivecraft_version=26.1.1-1.3.7-b2-fabric
-flashback_version=VaqZB1DF
+chunky_version=4Eotm6ov
+vivecraft_version=26.2-1.3.12-fabric
+flashback_version=0.41.1
 nvidium_version=0.4.1-beta4:1.21.6@jar
 
 
 # Mod Properties
-mod_version = 0.2.17-beta
+mod_version = 0.2.18-beta
 maven_group = me.cortex
 archives_base_name = voxy

--- a/src/main/java/me/cortex/voxy/client/ClientImportManager.java
+++ b/src/main/java/me/cortex/voxy/client/ClientImportManager.java
@@ -6,7 +6,6 @@ import me.cortex.voxy.commonImpl.importers.IDataImporter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Mth;
 import net.minecraft.world.BossEvent;
 import java.util.UUID;
 
@@ -20,7 +19,7 @@ public class ClientImportManager extends ImportManager {
             this.bossbarUUID = UUID.randomUUID();
             this.bossBar = new LerpingBossEvent(this.bossbarUUID, Component.nullToEmpty("Voxy world importer"), 0.0f, BossEvent.BossBarColor.GREEN, BossEvent.BossBarOverlay.PROGRESS, false, false, false);
             Minecraft.getInstance().execute(()->{
-                Minecraft.getInstance().gui.getBossOverlay().events.put(bossBar.getId(), bossBar);
+                Minecraft.getInstance().gui.hud.getBossOverlay().events.put(bossBar.getId(), bossBar);
             });
         }
 
@@ -40,11 +39,11 @@ public class ClientImportManager extends ImportManager {
         protected void onCompleted(int total) {
             super.onCompleted(total);
             Minecraft.getInstance().execute(()->{
-                Minecraft.getInstance().gui.getBossOverlay().events.remove(this.bossbarUUID);
+                Minecraft.getInstance().gui.hud.getBossOverlay().events.remove(this.bossbarUUID);
                 long delta = Math.max(System.currentTimeMillis() - this.startTime, 1);
 
                 String msg = "Voxy world import finished in " + (delta/1000) + " seconds, averaging " + (int)(total/(delta/1000f)) + " chunks per second";
-                Minecraft.getInstance().gui.getChat().addClientSystemMessage(Component.literal(msg));
+                Minecraft.getInstance().gui.hud.getChat().addClientSystemMessage(Component.literal(msg));
                 Logger.info(msg);
             });
         }

--- a/src/main/java/me/cortex/voxy/client/DebugEntries.java
+++ b/src/main/java/me/cortex/voxy/client/DebugEntries.java
@@ -60,7 +60,7 @@ public class DebugEntries {
 
             GPUTiming.INSTANCE.setEnabled(previousGpuDebugEnabled);
             RenderStatistics.enabled = previousGpuDebugEnabled;
-            var renderer = Minecraft.getInstance().levelRenderer;
+            var renderer = Minecraft.getInstance().levelExtractor;
             if (renderer!=null)renderer.allChanged();
         }
     }

--- a/src/main/java/me/cortex/voxy/client/VoxyCommands.java
+++ b/src/main/java/me/cortex/voxy/client/VoxyCommands.java
@@ -90,7 +90,7 @@ public class VoxyCommands {
         System.gc();
         VoxyCommon.createInstance();
 
-        var r = Minecraft.getInstance().levelRenderer;
+        var r = Minecraft.getInstance().levelExtractor;
         if (r != null) r.allChanged();
         return 0;
     }

--- a/src/main/java/me/cortex/voxy/client/core/IGetVoxyRenderSystem.java
+++ b/src/main/java/me/cortex/voxy/client/core/IGetVoxyRenderSystem.java
@@ -6,6 +6,7 @@ public interface IGetVoxyRenderSystem {
     VoxyRenderSystem voxy$getRenderSystem();
     void voxy$shutdownRenderer();
     void voxy$createRenderer();
+    void voxy$setRenderer(VoxyRenderSystem voxyRenderSystem);
 
     static VoxyRenderSystem getNullable() {
         var lr = (IGetVoxyRenderSystem)Minecraft.getInstance().levelRenderer;

--- a/src/main/java/me/cortex/voxy/client/core/RenderProperties.java
+++ b/src/main/java/me/cortex/voxy/client/core/RenderProperties.java
@@ -61,7 +61,7 @@ public record RenderProperties(boolean isZero2One, boolean isReverseZ, boolean u
 
     public static RenderProperties getRenderProperties() {
         RenderProperties properties = new RenderProperties(
-                RenderSystem.getDevice().isZZeroToOne(),
+                RenderSystem.getDevice().getDeviceInfo().isZZeroToOne(),
                 DepthStencilState.DEFAULT.depthTest().equals(CompareOp.GREATER_THAN_OR_EQUAL),
                 false);
 

--- a/src/main/java/me/cortex/voxy/client/core/VoxyRenderSystem.java
+++ b/src/main/java/me/cortex/voxy/client/core/VoxyRenderSystem.java
@@ -36,6 +36,7 @@ import net.minecraft.network.chat.Component;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL33C;
 
 import java.util.Arrays;
 import java.util.List;
@@ -68,6 +69,8 @@ public class VoxyRenderSystem {
     private final AbstractRenderPipeline pipeline;
     private final RenderProperties properties;
 
+    private int voxyProxyFbo = 0;
+
     private static AbstractSectionRenderer.Factory<?,? extends IGeometryData> getRenderBackendFactory() {
         //TODO: need todo a thing where selects optimal section render based on if supports the pipeline and geometry data type
         return MDICSectionRenderer.FACTORY;
@@ -84,7 +87,7 @@ public class VoxyRenderSystem {
         if (Minecraft.getInstance().options.renderDistance().get()<3) {
             String msg = "Voxy: Having a vanilla render distance of 2 can cause rare culling near the edge of your screen issues, please use 3 or more";
             Logger.warn(msg);
-            Minecraft.getInstance().getChatListener().handleSystemMessage(Component.literal(msg), false);
+            Minecraft.getInstance().gui.chatListener().handleSystemMessage(Component.literal(msg), false);
         }
 
         //Fking HATE EVERYTHING AAAAAAAAAAAAAAAA
@@ -245,6 +248,36 @@ public class VoxyRenderSystem {
         int oldFB = GL11.glGetInteger(GL_DRAW_FRAMEBUFFER_BINDING);
         int boundFB = oldFB;
 
+        // TODO: I think it's not perfect, there might be a way around that I don't know for now, also not compatible with Vulkan
+        // If OpenGL returns backbuffer (0), we intercept with the FBO proxy
+        if (boundFB == 0) {
+            var mainTarget = Minecraft.getInstance().gameRenderer.mainRenderTarget();
+            var colorTex = mainTarget.getColorTexture();
+            var depthTex = mainTarget.getDepthTexture();
+
+            if (colorTex != null && depthTex != null) {
+                // Création paresseuse de notre FBO
+                if (this.voxyProxyFbo == 0) {
+                    this.voxyProxyFbo = GlStateManager.glGenFramebuffers();
+                }
+
+                int colorId = ((com.mojang.blaze3d.opengl.GlTexture) colorTex).glId();
+                int depthId = ((com.mojang.blaze3d.opengl.GlTexture) depthTex).glId();
+
+                // bind our FBO and attach the two textures
+                GlStateManager._glBindFramebuffer(GL33C.GL_FRAMEBUFFER, this.voxyProxyFbo);
+                GlStateManager._glFramebufferTexture2D(GL33C.GL_FRAMEBUFFER, GL33C.GL_COLOR_ATTACHMENT0, GL33C.GL_TEXTURE_2D, colorId, 0);
+                GlStateManager._glFramebufferTexture2D(GL33C.GL_FRAMEBUFFER, GL33C.GL_DEPTH_ATTACHMENT, GL33C.GL_TEXTURE_2D, depthId, 0);
+
+                // we now have a valid framebuffer to work with
+                boundFB = this.voxyProxyFbo;
+            }
+        }
+
+        if (boundFB == 0) {
+            throw new IllegalStateException("Cannot use the default framebuffer as cannot source from it");
+        }
+
         int[] dims = new int[4];
         glGetIntegerv(GL_VIEWPORT, dims);
 
@@ -252,6 +285,7 @@ public class VoxyRenderSystem {
 
         //var target = DefaultTerrainRenderPasses.CUTOUT.getTarget();
         //boundFB = ((net.minecraft.client.texture.GlTexture) target.getColorAttachment()).getOrCreateFramebuffer(((GlBackend) RenderSystem.getDevice()).getFramebufferManager(), target.getDepthAttachment());
+
         if (boundFB == 0) {
             throw new IllegalStateException("Cannot use the default framebuffer as cannot source from it");
         }
@@ -415,7 +449,7 @@ public class VoxyRenderSystem {
     private static Matrix4f computeProjectionMat(RenderProperties properties, Matrix4fc base) {
 
         //this jank is to capture the extra crap they inject like viewbobbing
-        var rawMCProj = Minecraft.getInstance().gameRenderer.getGameRenderState().levelRenderState.cameraRenderState.projectionMatrix;
+        var rawMCProj = Minecraft.getInstance().gameRenderer.gameRenderState().levelRenderState.cameraRenderState.projectionMatrix;
         var extraProjection = rawMCProj.invert(new Matrix4f()).mul(base);
 
         float near = getRenderDistance()<=32.0f?8f:16f;

--- a/src/main/java/me/cortex/voxy/client/core/model/ModelFactory.java
+++ b/src/main/java/me/cortex/voxy/client/core/model/ModelFactory.java
@@ -696,32 +696,7 @@ public class ModelFactory {
     }
 
     private static int getBlockLightEmission(BlockState state) {
-        boolean isEmissive = state.emissiveRendering(new BlockGetter() {
-            @Override
-            public @org.jspecify.annotations.Nullable BlockEntity getBlockEntity(BlockPos pos) {
-                return null;
-            }
-
-            @Override
-            public BlockState getBlockState(BlockPos pos) {
-                return state;
-            }
-
-            @Override
-            public FluidState getFluidState(BlockPos pos) {
-                return state.getFluidState();
-            }
-
-            @Override
-            public int getHeight() {
-                return 0;
-            }
-
-            @Override
-            public int getMinY() {
-                return 0;
-            }
-        }, BlockPos.ZERO);
+        boolean isEmissive = state.emissiveRendering();
         if (isEmissive) {
             return 15;//full bright
         }

--- a/src/main/java/me/cortex/voxy/client/core/model/bakery/SoftwareModelTextureBakery.java
+++ b/src/main/java/me/cortex/voxy/client/core/model/bakery/SoftwareModelTextureBakery.java
@@ -1,11 +1,7 @@
 package me.cortex.voxy.client.core.model.bakery;
 
-import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.opengl.GlTexture;
-import com.mojang.blaze3d.platform.NativeImage;
-import com.mojang.blaze3d.systems.CommandEncoder;
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.textures.TextureFormat;
 import com.mojang.blaze3d.vertex.PoseStack;
 import me.cortex.voxy.client.core.model.ModelFactory;
 import me.cortex.voxy.common.util.UnsafeUtil;
@@ -14,7 +10,6 @@ import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.block.FluidRenderer;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
-import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.Identifier;
@@ -23,7 +18,6 @@ import net.minecraft.world.level.CardinalLighting;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -37,15 +31,11 @@ import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import org.lwjgl.system.MemoryUtil;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.lwjgl.opengl.ARBDirectStateAccess.glGetTextureImage;
 import static org.lwjgl.opengl.GL11.*;
-import static org.lwjgl.opengl.GL11.GL_UNPACK_ALIGNMENT;
 import static org.lwjgl.opengl.GL11C.GL_RGBA;
 import static org.lwjgl.opengl.GL12.GL_PACK_IMAGE_HEIGHT;
 import static org.lwjgl.opengl.GL15C.glBindBuffer;
@@ -68,7 +58,8 @@ public class SoftwareModelTextureBakery {
 
     public void setupTexture() {
         var tex = Minecraft.getInstance().getTextureManager().getTexture(Identifier.fromNamespaceAndPath("minecraft", "textures/atlas/blocks.png")).getTexture();
-        if (tex.getFormat() != TextureFormat.RGBA8) {
+        System.out.println("Block atlas format: "+tex.getFormat());
+        if (!List.of(GpuFormat.RGBA8_SINT, GpuFormat.RGBA8_SNORM, GpuFormat.RGBA8_UINT, GpuFormat.RGBA8_UNORM).contains(tex.getFormat())) {
             throw new IllegalStateException("Block atlas not rgba8");
         }
 

--- a/src/main/java/me/cortex/voxy/client/core/model/bakery/SoftwareModelTextureBakery.java
+++ b/src/main/java/me/cortex/voxy/client/core/model/bakery/SoftwareModelTextureBakery.java
@@ -58,7 +58,7 @@ public class SoftwareModelTextureBakery {
 
     public void setupTexture() {
         var tex = Minecraft.getInstance().getTextureManager().getTexture(Identifier.fromNamespaceAndPath("minecraft", "textures/atlas/blocks.png")).getTexture();
-        System.out.println("Block atlas format: "+tex.getFormat());
+
         if (!List.of(GpuFormat.RGBA8_SINT, GpuFormat.RGBA8_SNORM, GpuFormat.RGBA8_UINT, GpuFormat.RGBA8_UNORM).contains(tex.getFormat())) {
             throw new IllegalStateException("Block atlas not rgba8");
         }

--- a/src/main/java/me/cortex/voxy/client/mixin/iris/MixinLevelRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/iris/MixinLevelRenderer.java
@@ -6,13 +6,11 @@ import me.cortex.voxy.client.core.IGetVoxyRenderSystem;
 import me.cortex.voxy.client.core.util.IrisUtil;
 import net.caffeinemc.mods.sodium.client.render.chunk.ChunkRenderMatrices;
 import net.caffeinemc.mods.sodium.client.util.FogStorage;
-import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
-import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
-import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Final;
@@ -26,19 +24,19 @@ import static org.lwjgl.opengl.GL11C.glViewport;
 
 @Mixin(LevelRenderer.class)
 public class MixinLevelRenderer {
-    @Shadow @Final private Minecraft minecraft;
+    @Shadow @Final private GameRenderer gameRenderer;
 
-    @Inject(method = "renderLevel", at = @At("HEAD"), order = 100)
+    @Inject(method = "render", at = @At("HEAD"), order = 100)
     private void voxy$injectIrisCompat(
-            GraphicsResourceAllocator resourceAllocator, DeltaTracker deltaTracker, boolean renderOutline, CameraRenderState cameraState, Matrix4fc modelViewMatrix, GpuBufferSlice terrainFog, Vector4f fogColor, boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender, CallbackInfo ci) {
+            GraphicsResourceAllocator resourceAllocator, DeltaTracker deltaTracker, boolean renderOutline, CameraRenderState cameraState, Matrix4fc modelViewMatrix, GpuBufferSlice terrainFog, Vector4f fogColor, boolean shouldRenderSky, CallbackInfo ci) {
         if (IrisUtil.irisShaderPackEnabled()) {
             var renderer = ((IGetVoxyRenderSystem) this).voxy$getRenderSystem();
             if (renderer != null) {
                 //Fixthe fucking viewport dims, fuck iris
-                glViewport(0,0,Minecraft.getInstance().getMainRenderTarget().width, Minecraft.getInstance().getMainRenderTarget().height);
+                glViewport(0,0,Minecraft.getInstance().gameRenderer.mainRenderTarget().width, Minecraft.getInstance().gameRenderer.mainRenderTarget().height);
 
                 var pos = cameraState.pos;
-                IrisUtil.CAPTURED_VIEWPORT_PARAMETERS = new IrisUtil.CapturedViewportParameters(new ChunkRenderMatrices(cameraState.projectionMatrix, cameraState.viewRotationMatrix), ((FogStorage) this.minecraft.gameRenderer).sodium$getFogParameters(), pos.x, pos.y, pos.z);
+                IrisUtil.CAPTURED_VIEWPORT_PARAMETERS = new IrisUtil.CapturedViewportParameters(new ChunkRenderMatrices(cameraState.projectionMatrix, cameraState.viewRotationMatrix), ((FogStorage) gameRenderer).sodium$getFogParameters(), pos.x, pos.y, pos.z);
             }
         }
     }

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinClientLevel.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinClientLevel.java
@@ -3,12 +3,11 @@ package me.cortex.voxy.client.mixin.minecraft;
 import me.cortex.voxy.client.config.VoxyConfig;
 import me.cortex.voxy.common.world.service.VoxelIngestService;
 import me.cortex.voxy.commonImpl.VoxyCommon;
-import me.cortex.voxy.commonImpl.VoxyInstance;
 import me.cortex.voxy.commonImpl.WorldIdentifier;
 import net.minecraft.client.multiplayer.ClientChunkCache;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.ClientPacketListener;
-import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.extract.LevelExtractor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.SectionPos;
@@ -18,7 +17,6 @@ import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
 import net.minecraft.world.level.dimension.DimensionType;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -32,23 +30,20 @@ public abstract class MixinClientLevel {
     @Unique
     private int bottomSectionY;
 
-    @Shadow @Final public LevelRenderer levelRenderer;
-
     @Shadow public abstract ClientChunkCache getChunkSource();
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void voxy$getBottom(
-            ClientPacketListener networkHandler,
-            ClientLevel.ClientLevelData properties,
-            ResourceKey<Level> registryRef,
-            Holder<DimensionType> dimensionType,
-            int loadDistance,
-            int simulationDistance,
-            LevelRenderer worldRenderer,
-            boolean debugWorld,
-            long seed,
-            int seaLevel,
-            CallbackInfo cir) {
+            final ClientPacketListener connection,
+            final ClientLevel.ClientLevelData levelData,
+            final ResourceKey<Level> dimension,
+            final Holder<DimensionType> dimensionType,
+            final int serverChunkRadius,
+            final int serverSimulationDistance,
+            final LevelExtractor levelExtractor,
+            final boolean isDebug,
+            final long biomeZoomSeed,
+            final int seaLevel, CallbackInfo ci) {
         this.bottomSectionY = ((Level)(Object)this).getMinY()>>4;
     }
 

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinFogRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinFogRenderer.java
@@ -1,21 +1,15 @@
 package me.cortex.voxy.client.mixin.minecraft;
 
-import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
-import com.llamalad7.mixinextras.sugar.Local;
 import me.cortex.voxy.client.config.VoxyConfig;
 import me.cortex.voxy.client.core.IGetVoxyRenderSystem;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.fog.FogData;
 import net.minecraft.client.renderer.fog.FogRenderer;
-import org.joml.Vector4f;
-import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = FogRenderer.class, priority = 900)//We must execute before sodium

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinGPUSelect.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinGPUSelect.java
@@ -1,9 +1,5 @@
 package me.cortex.voxy.client.mixin.minecraft;
 
-import com.mojang.blaze3d.platform.DisplayData;
-import com.mojang.blaze3d.platform.ScreenManager;
-import com.mojang.blaze3d.platform.Window;
-import com.mojang.blaze3d.platform.WindowEventHandler;
 import me.cortex.voxy.client.GPUSelectorWindows2;
 import me.cortex.voxy.common.util.ThreadUtils;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinLevelExtractor.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinLevelExtractor.java
@@ -1,0 +1,93 @@
+package me.cortex.voxy.client.mixin.minecraft;
+
+import me.cortex.voxy.client.VoxyClientInstance;
+import me.cortex.voxy.client.config.VoxyConfig;
+import me.cortex.voxy.client.core.IGetVoxyRenderSystem;
+import me.cortex.voxy.client.core.VoxyRenderSystem;
+import me.cortex.voxy.client.core.util.IrisUtil;
+import me.cortex.voxy.common.Logger;
+import me.cortex.voxy.common.world.WorldEngine;
+import me.cortex.voxy.commonImpl.VoxyCommon;
+import me.cortex.voxy.commonImpl.WorldIdentifier;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.extract.LevelExtractor;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LevelExtractor.class)
+public abstract class MixinLevelExtractor implements IGetVoxyRenderSystem {
+    @Shadow private @Nullable ClientLevel level;
+
+    @Shadow
+    @Final
+    public LevelRenderer levelRenderer;
+
+    @Override
+    public VoxyRenderSystem voxy$getRenderSystem() {
+        return ((IGetVoxyRenderSystem) levelRenderer).voxy$getRenderSystem();
+    }
+
+    @Inject(method = "allChanged()V", at = @At("RETURN"), order = 900)//We want to inject before sodium
+    private void voxy$reloadVoxyRenderer(CallbackInfo ci) {
+        this.voxy$shutdownRenderer();
+        if (this.level != null) {
+            this.voxy$createRenderer();
+        }
+    }
+
+    @Inject(method = "setLevel", at = @At("HEAD"))
+    private void voxy$captureSetWorld(ClientLevel world, CallbackInfo ci) {
+        if (this.level != world) {
+            this.voxy$shutdownRenderer();
+        }
+    }
+
+    @Override
+    public void voxy$shutdownRenderer() {
+        ((IGetVoxyRenderSystem) levelRenderer).voxy$shutdownRenderer();
+    }
+
+    @Override
+    public void voxy$createRenderer() {
+        if (((IGetVoxyRenderSystem) levelRenderer).voxy$getRenderSystem() != null) throw new IllegalStateException("Cannot have multiple renderers");
+        if (!VoxyConfig.CONFIG.enabled) {
+            Logger.info("Not creating renderer due to disabled");
+            return;
+        }
+        if (!VoxyConfig.CONFIG.isRenderingEnabled()) {
+            Logger.info("Not creating renderer due to disabled rendering");
+            return;
+        }
+        if (this.level == null) {
+            Logger.error("Not creating renderer due to null world");
+            return;
+        }
+        var instance = (VoxyClientInstance)VoxyCommon.getInstance();
+        if (instance == null) {
+            //This is now legal (e.g. when the instance is disabled)
+            Logger.info("Not creating renderer due to null instance");
+            return;
+        }
+        WorldEngine world = WorldIdentifier.ofEngine(this.level);
+        if (world == null) {
+            Logger.error("Null world selected");
+            return;
+        }
+        try {
+            ((IGetVoxyRenderSystem) levelRenderer).voxy$setRenderer(new VoxyRenderSystem(world, instance.getServiceManager()));
+        } catch (RuntimeException e) {
+            if (IrisUtil.irisShaderPackEnabled()) {
+                IrisUtil.disableIrisShaders();
+            } else {
+                throw e;
+            }
+        }
+        instance.updateDedicatedThreads();
+    }
+}

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinLevelRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinLevelRenderer.java
@@ -1,19 +1,9 @@
 package me.cortex.voxy.client.mixin.minecraft;
 
-import me.cortex.voxy.client.VoxyClientInstance;
-import me.cortex.voxy.client.config.VoxyConfig;
 import me.cortex.voxy.client.core.IGetVoxyRenderSystem;
 import me.cortex.voxy.client.core.VoxyRenderSystem;
-import me.cortex.voxy.client.core.util.IrisUtil;
-import me.cortex.voxy.common.Logger;
-import me.cortex.voxy.common.world.WorldEngine;
-import me.cortex.voxy.commonImpl.VoxyCommon;
-import me.cortex.voxy.commonImpl.WorldIdentifier;
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.LevelRenderer;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -21,27 +11,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LevelRenderer.class)
 public abstract class MixinLevelRenderer implements IGetVoxyRenderSystem {
-    @Shadow private @Nullable ClientLevel level;
     @Unique private VoxyRenderSystem renderer;
 
     @Override
     public VoxyRenderSystem voxy$getRenderSystem() {
         return this.renderer;
-    }
-
-    @Inject(method = "allChanged()V", at = @At("RETURN"), order = 900)//We want to inject before sodium
-    private void voxy$reloadVoxyRenderer(CallbackInfo ci) {
-        this.voxy$shutdownRenderer();
-        if (this.level != null) {
-            this.voxy$createRenderer();
-        }
-    }
-
-    @Inject(method = "setLevel", at = @At("HEAD"))
-    private void voxy$captureSetWorld(ClientLevel world, CallbackInfo ci) {
-        if (this.level != world) {
-            this.voxy$shutdownRenderer();
-        }
     }
 
     @Inject(method = "close", at = @At("HEAD"))
@@ -58,40 +32,7 @@ public abstract class MixinLevelRenderer implements IGetVoxyRenderSystem {
     }
 
     @Override
-    public void voxy$createRenderer() {
-        if (this.renderer != null) throw new IllegalStateException("Cannot have multiple renderers");
-        if (!VoxyConfig.CONFIG.enabled) {
-            Logger.info("Not creating renderer due to disabled");
-            return;
-        }
-        if (!VoxyConfig.CONFIG.isRenderingEnabled()) {
-            Logger.info("Not creating renderer due to disabled rendering");
-            return;
-        }
-        if (this.level == null) {
-            Logger.error("Not creating renderer due to null world");
-            return;
-        }
-        var instance = (VoxyClientInstance)VoxyCommon.getInstance();
-        if (instance == null) {
-            //This is now legal (e.g. when the instance is disabled)
-            Logger.info("Not creating renderer due to null instance");
-            return;
-        }
-        WorldEngine world = WorldIdentifier.ofEngine(this.level);
-        if (world == null) {
-            Logger.error("Null world selected");
-            return;
-        }
-        try {
-            this.renderer = new VoxyRenderSystem(world, instance.getServiceManager());
-        } catch (RuntimeException e) {
-            if (IrisUtil.irisShaderPackEnabled()) {
-                IrisUtil.disableIrisShaders();
-            } else {
-                throw e;
-            }
-        }
-        instance.updateDedicatedThreads();
+    public void voxy$setRenderer(VoxyRenderSystem renderer) {
+        this.renderer = renderer;
     }
 }

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinRenderSystem.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinRenderSystem.java
@@ -1,18 +1,13 @@
 package me.cortex.voxy.client.mixin.minecraft;
 
 
-import com.mojang.blaze3d.shaders.ShaderSource;
-import com.mojang.blaze3d.shaders.ShaderType;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderSystem;
 import me.cortex.voxy.client.VoxyClient;
-import net.minecraft.resources.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.function.BiFunction;
 
 //Thanks iris for making me need todo this ;-; _irritater_
 @Mixin(RenderSystem.class)

--- a/src/main/java/me/cortex/voxy/client/mixin/nvidium/MixinRenderPipeline.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/nvidium/MixinRenderPipeline.java
@@ -1,6 +1,5 @@
 package me.cortex.voxy.client.mixin.nvidium;
 
-import com.mojang.blaze3d.textures.GpuSampler;
 import me.cortex.nvidium.RenderPipeline;
 import me.cortex.voxy.client.core.IGetVoxyRenderSystem;
 import net.caffeinemc.mods.sodium.client.render.chunk.ChunkRenderMatrices;
@@ -16,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = RenderPipeline.class, remap = false)
 public class MixinRenderPipeline {
     @Inject(method = "renderFrame", at = @At("RETURN"))
-    private void voxy$injectRender(TerrainRenderPass pass, Viewport frustum, FogParameters fogParameters, ChunkRenderMatrices crm, double px, double py, double pz, GpuSampler terrainSampler, CallbackInfo ci) {
+    private void voxy$injectRender(TerrainRenderPass pass, Viewport frustum, FogParameters fogParameters, ChunkRenderMatrices crm, double px, double py, double pz, CallbackInfo ci) {
         var renderer = ((IGetVoxyRenderSystem) Minecraft.getInstance().levelRenderer).voxy$getRenderSystem();
         if (renderer != null) {
             renderer.renderOpaque(renderer.setupViewport(crm.projection(), crm.modelView(), fogParameters, px, py, pz));

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinDefaultChunkRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinDefaultChunkRenderer.java
@@ -1,12 +1,11 @@
 package me.cortex.voxy.client.mixin.sodium;
 
+import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.textures.GpuSampler;
 import me.cortex.voxy.client.VoxyClient;
 import me.cortex.voxy.client.core.IGetVoxyRenderSystem;
 import me.cortex.voxy.client.core.rendering.Viewport;
 import me.cortex.voxy.client.core.util.IrisUtil;
-import net.caffeinemc.mods.sodium.client.gl.device.CommandList;
-import net.caffeinemc.mods.sodium.client.gl.device.RenderDevice;
 import net.caffeinemc.mods.sodium.client.render.chunk.ChunkRenderMatrices;
 import net.caffeinemc.mods.sodium.client.render.chunk.DefaultChunkRenderer;
 import net.caffeinemc.mods.sodium.client.render.chunk.ShaderChunkRenderer;
@@ -26,12 +25,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = DefaultChunkRenderer.class, remap = false)
 public abstract class MixinDefaultChunkRenderer extends ShaderChunkRenderer {
 
-    public MixinDefaultChunkRenderer(RenderDevice device, ChunkVertexType vertexType) {
-        super(device, vertexType);
+    public MixinDefaultChunkRenderer(ChunkVertexType vertexType) {
+        super(vertexType);
     }
 
     @Inject(method = "render", at = @At(value = "HEAD"), cancellable = true)
-    private void voxy$cancelThingie(ChunkRenderMatrices matrices, CommandList commandList, ChunkRenderListIterable renderLists, TerrainRenderPass renderPass, CameraTransform camera, FogParameters fogParameters, boolean indexedRenderingEnabled, GpuSampler terrainSampler, CallbackInfo ci) {
+    private void voxy$cancelThingie(ChunkRenderMatrices matrices, ChunkRenderListIterable renderLists, TerrainRenderPass renderPass, CameraTransform camera, FogParameters fogParameters, boolean indexedRenderingEnabled, GpuSampler terrainSampler, GpuBuffer uniformData, GpuBuffer sectionTimeInfo, CallbackInfo ci) {
         if (VoxyClient.disableSodiumChunkRender()) {
             super.begin(renderPass, fogParameters, terrainSampler);
             this.doRender(matrices, renderPass, camera, fogParameters);
@@ -41,7 +40,7 @@ public abstract class MixinDefaultChunkRenderer extends ShaderChunkRenderer {
     }
 
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/ShaderChunkRenderer;end(Lnet/caffeinemc/mods/sodium/client/render/chunk/terrain/TerrainRenderPass;)V", shift = At.Shift.BEFORE))
-    private void voxy$injectRender(ChunkRenderMatrices matrices, CommandList commandList, ChunkRenderListIterable renderLists, TerrainRenderPass renderPass, CameraTransform camera, FogParameters fogParameters, boolean indexedRenderingEnabled, GpuSampler terrainSampler, CallbackInfo ci) {
+    private void voxy$injectRender(ChunkRenderMatrices matrices, ChunkRenderListIterable renderLists, TerrainRenderPass renderPass, CameraTransform camera, FogParameters fogParameters, boolean indexedRenderingEnabled, GpuSampler terrainSampler, GpuBuffer uniformData, GpuBuffer sectionTimeInfo, CallbackInfo ci) {
         this.doRender(matrices, renderPass, camera, fogParameters);
     }
 

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinRenderRegionManager.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinRenderRegionManager.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(value = RenderRegionManager.class, remap = false)
 public class MixinRenderRegionManager {
-    @Redirect(method = "uploadResults(Lnet/caffeinemc/mods/sodium/client/gl/device/CommandList;Lnet/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion;Ljava/util/Collection;)V", at = @At(value = "INVOKE", target = "Ljava/lang/Math;toIntExact(J)I"), remap = false)
+    @Redirect(method = "uploadResults(Lnet/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion;Ljava/util/Collection;Lnet/caffeinemc/mods/sodium/client/render/chunk/UniformBufferManager;)V", at = @At(value = "INVOKE", target = "Ljava/lang/Math;toIntExact(J)I"), remap = false)
     private int voxy$cancelFade(long time) {
         var vrs = ((IGetVoxyRenderSystem)(Minecraft.getInstance().levelRenderer)).voxy$getRenderSystem();
         if (vrs!=null) {

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinRenderSectionManager.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinRenderSectionManager.java
@@ -6,7 +6,6 @@ import me.cortex.voxy.client.core.IGetVoxyRenderSystem;
 import me.cortex.voxy.client.core.VoxyRenderSystem;
 import me.cortex.voxy.common.world.service.VoxelIngestService;
 import me.cortex.voxy.commonImpl.VoxyCommon;
-import net.caffeinemc.mods.sodium.client.gl.device.CommandList;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSectionManager;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.executor.ChunkBuilder;
@@ -38,9 +37,9 @@ public class MixinRenderSectionManager {
     @Shadow @Final private ChunkBuilder builder;
 
     @Inject(method = "<init>", at = @At("TAIL"))
-    private void voxy$resetChunkTracker(ClientLevel level, int renderDistance, SortBehavior sortBehavior, CommandList commandList, CallbackInfo ci) {
-        if (level.levelRenderer != null) {
-            var system = ((IGetVoxyRenderSystem)(level.levelRenderer)).voxy$getRenderSystem();
+    private void voxy$resetChunkTracker(ClientLevel level, int renderDistance, SortBehavior sortBehavior, CallbackInfo ci) {
+        if (level.levelExtractor.levelRenderer != null) {
+            var system = ((IGetVoxyRenderSystem)(level.levelExtractor.levelRenderer)).voxy$getRenderSystem();
             if (system != null) {
                 system.chunkBoundRenderer.reset();
             }
@@ -65,7 +64,7 @@ public class MixinRenderSectionManager {
 
     @Inject(method = "onChunkAdded", at = @At("HEAD"))
     private void voxy$ingestOnAdd(int x, int z, CallbackInfo ci) {
-        if (this.level.levelRenderer != null && VoxyConfig.CONFIG.ingestEnabled) {
+        if (this.level.levelExtractor.levelRenderer != null && VoxyConfig.CONFIG.ingestEnabled) {
             var cccm = this.level.getChunkSource();
             if (cccm != null) {
                 var chunk = cccm.getChunk(x, z, ChunkStatus.FULL, false);
@@ -91,24 +90,24 @@ public class MixinRenderSectionManager {
     @Unique private int cachedChunkStatus;
     @Unique private int bottomSectionY;
 
-    @Redirect(method = "updateSectionInfo", at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSection;setInfo(Lnet/caffeinemc/mods/sodium/client/render/chunk/data/BuiltSectionInfo;)Z"))
-    private boolean voxy$updateOnUpload(RenderSection instance, BuiltSectionInfo info) {
-        boolean wasBuilt = instance.getFlags()!=0;
-        int flags = instance.getFlags();
-        if (!instance.setInfo(info)) {
-            return false;
+    @Redirect(method = "updateSectionInfo", at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSection;setInfo(Lnet/caffeinemc/mods/sodium/client/render/chunk/data/BuiltSectionInfo;)I"))
+    private int voxy$updateOnUpload(RenderSection instance, BuiltSectionInfo info) {
+        boolean wasBuilt = instance.getRegion().getSectionFlags(instance.getSectionIndex())!=0;
+        int flags = instance.getRegion().getSectionFlags(instance.getSectionIndex());
+        if (instance.setInfo(info) == 0) {
+            return 0;
         }
-        if (wasBuilt == (instance.getFlags()!=0)) {//Only want to do stuff on change
-            return true;
+        if (wasBuilt == (instance.getRegion().getSectionFlags(instance.getSectionIndex())!=0)) {//Only want to do stuff on change
+            return 1;
         }
 
-        flags |= instance.getFlags();
+        flags |= instance.getRegion().getSectionFlags(instance.getSectionIndex());
         if (flags == 0)//Only process things with stuff
-            return true;
+            return 1;
 
-        VoxyRenderSystem system = ((IGetVoxyRenderSystem)(this.level.levelRenderer)).voxy$getRenderSystem();
+        VoxyRenderSystem system = ((IGetVoxyRenderSystem)(this.level.levelExtractor.levelRenderer)).voxy$getRenderSystem();
         if (system == null) {
-            return true;
+            return 1;
         }
         int x = instance.getChunkX(), y = instance.getChunkY(), z = instance.getChunkZ();
 
@@ -156,6 +155,6 @@ public class MixinRenderSectionManager {
         } else {//Add
             system.chunkBoundRenderer.addSection(pos);
         }
-        return true;
+        return 1;
     }
 }

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinSodiumWorldRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinSodiumWorldRenderer.java
@@ -1,8 +1,6 @@
 package me.cortex.voxy.client.mixin.sodium;
 
 import me.cortex.voxy.commonImpl.VoxyCommon;
-import me.cortex.voxy.commonImpl.VoxyInstance;
-import net.caffeinemc.mods.sodium.client.gl.device.CommandList;
 import net.caffeinemc.mods.sodium.client.render.SodiumWorldRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = SodiumWorldRenderer.class, remap = false)
 public class MixinSodiumWorldRenderer {
     @Inject(method = "initRenderer", at = @At("TAIL"), remap = false)
-    private void voxy$injectThreadUpdate(CommandList cl, CallbackInfo ci) {
+    private void voxy$injectThreadUpdate(CallbackInfo ci) {
         var vi = VoxyCommon.getInstance();
         if (vi != null) vi.updateDedicatedThreads();
     }

--- a/src/main/java/me/cortex/voxy/common/Logger.java
+++ b/src/main/java/me/cortex/voxy/common/Logger.java
@@ -62,7 +62,7 @@ public class Logger {
         if (instance != null) {
             instance.executeIfPossible(() -> {
                 var player = Minecraft.getInstance().player;
-                if (player != null) instance.getChatListener().handleSystemMessage(Component.literal(msg), true);
+                if (player != null) instance.gui.chatListener().handleSystemMessage(Component.literal(msg), true);
             });
         }
     }

--- a/src/main/java/me/cortex/voxy/commonImpl/importers/WorldImporter.java
+++ b/src/main/java/me/cortex/voxy/commonImpl/importers/WorldImporter.java
@@ -101,6 +101,11 @@ public class WorldImporter implements IDataImporter {
             }
 
             @Override
+            public void forEachInPalette(Consumer<Holder<Biome>> consumer) {
+
+            }
+
+            @Override
             public void count(PalettedContainer.CountConsumer<Holder<Biome>> counter) {
 
             }

--- a/src/main/resources/client.voxy.mixins.json
+++ b/src/main/resources/client.voxy.mixins.json
@@ -23,6 +23,7 @@
     "minecraft.MixinDebugScreenEntryList",
     "minecraft.MixinFogRenderer",
     "minecraft.MixinGlDebug",
+    "minecraft.MixinLevelExtractor",
     "minecraft.MixinLevelRenderer",
     "minecraft.MixinMinecraft",
     "minecraft.MixinRenderSystem",

--- a/src/main/resources/voxy.accesswidener
+++ b/src/main/resources/voxy.accesswidener
@@ -3,7 +3,9 @@ accessWidener v1 official
 accessible class net/minecraft/client/multiplayer/ClientChunkCache$Storage
 accessible class com/mojang/blaze3d/opengl/GlDebug$LogEntry
 
-accessible field net/minecraft/client/multiplayer/ClientLevel levelRenderer Lnet/minecraft/client/renderer/LevelRenderer;
+accessible field net/minecraft/client/multiplayer/ClientLevel levelExtractor Lnet/minecraft/client/renderer/extract/LevelExtractor;
+accessible field net/minecraft/client/renderer/extract/LevelExtractor levelRenderer Lnet/minecraft/client/renderer/LevelRenderer;
+
 accessible field com/mojang/blaze3d/opengl/GlBuffer handle I
 accessible field net/minecraft/client/renderer/texture/TextureAtlas maxMipLevel I
 accessible field net/minecraft/client/gui/components/BossHealthOverlay events Ljava/util/Map;


### PR DESCRIPTION
Ported Voxy for 26.2, compatible with OpenGL only
- Migrated to new hud distinction in gui
- Migrated to new distinction between LevelRenderer and LevelExtractor
- Migrated to new GpuFormat

The boundFB getting part might no be the best way to do it, but it seems to work for the testing I've done